### PR TITLE
fix(windows/macos): respect config.toml [font] over nvim's default guifont

### DIFF
--- a/include/zonvie_core.h
+++ b/include/zonvie_core.h
@@ -850,6 +850,18 @@ ZONVIE_API void zonvie_core_note_input_trace(
    gained: true when window gains focus, false when it loses focus */
 ZONVIE_API void zonvie_core_set_focus(zonvie_core *core, bool gained);
 
+/* Set a global Neovim option via nvim_set_option_value.
+   Used by frontends to sync the effective `guifont` back to Neovim so
+   `:set guifont?` reports what the frontend is actually rendering.
+   name: option name (e.g. "guifont")
+   value: option value string */
+ZONVIE_API void zonvie_core_set_option_value(
+    zonvie_core *core,
+    const unsigned char *name,
+    size_t name_len,
+    const unsigned char *value,
+    size_t value_len);
+
 /* Send a command to Neovim via nvim_command RPC (does not show in cmdline).
    cmd: command string (e.g., "lua vim.notify('hello')")
    len: length of command string */

--- a/include/zonvie_core.h
+++ b/include/zonvie_core.h
@@ -1150,6 +1150,11 @@ typedef struct zonvie_config_values {
     const char* font_family;
     float font_size;
     int32_t font_linespace;
+    /* True when the user explicitly set [font] family / size in config.toml.
+       Frontends should prefer config over nvim's default `guifont` (which
+       nvim sends at ui_attach even when the user hasn't set one). */
+    bool font_family_explicit;
+    bool font_size_explicit;
     // window
     bool window_blur;
     float window_opacity;

--- a/macos/Sources/App/Config.swift
+++ b/macos/Sources/App/Config.swift
@@ -41,6 +41,10 @@ struct ZonvieConfig {
         var family: String = "Menlo"
         var size: Double = 14.0
         var linespace: Int = 0
+        /// True when the user explicitly set [font] family / size in config.toml.
+        /// When true, onGuiFont prefers config over nvim's default guifont list.
+        var familyExplicit: Bool = false
+        var sizeExplicit: Bool = false
     }
 
     struct WindowConfig {
@@ -175,6 +179,8 @@ struct ZonvieConfig {
         if let s = v.font_family { config.font.family = String(cString: s) }
         config.font.size = Double(v.font_size)
         config.font.linespace = Int(v.font_linespace)
+        config.font.familyExplicit = v.font_family_explicit
+        config.font.sizeExplicit = v.font_size_explicit
 
         // Window
         config.window.blur = v.window_blur

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -2226,13 +2226,15 @@ final class ZonvieCore {
 
     /// Parse a single guifont entry: "<name>\t<size>" or "<name>\t<size>\t<features>".
     /// Returns (name, size, features) or nil if unparseable.
-    private static func parseGuiFontEntry(_ entry: String, configSize: Double) -> (String, Double, String)? {
+    /// When `sizeExplicit` is true, the parsed size is ignored and `configSize`
+    /// is used so that config.toml [font] size wins over nvim's default guifont.
+    private static func parseGuiFontEntry(_ entry: String, configSize: Double, sizeExplicit: Bool) -> (String, Double, String)? {
         let parts = entry.split(separator: "\t", maxSplits: 2, omittingEmptySubsequences: false)
         guard parts.count >= 2 else { return nil }
         let name = String(parts[0])
         guard !name.isEmpty else { return nil }
         let parsedSize = Double(parts[1]) ?? 0
-        let size = parsedSize > 0 ? parsedSize : configSize
+        let size = (sizeExplicit || parsedSize <= 0) ? configSize : parsedSize
         let features = parts.count >= 3 ? String(parts[2]) : ""
         return (name, size, features)
     }
@@ -2243,9 +2245,21 @@ final class ZonvieCore {
         let data = Data(bytes: bytes, count: max(0, len))
         guard let s = String(data: data, encoding: .utf8) else { return }
 
-        // Font priority: guifont > config.font.family > OS default (Menlo)
+        // Font priority:
+        //   1. config.font.family/size when explicitly set in config.toml
+        //   2. guifont payload from nvim
+        //   3. config.font defaults
+        //   4. OS default (Menlo)
+        //
+        // Nvim sends its own default `guifont` at ui_attach time even when
+        // the user hasn't set one. Letting that default override an explicit
+        // config.toml [font] entry surprises users. If the user wants
+        // `:set guifont=...` to control the font, they should leave [font]
+        // out of config.toml.
         let configFont = ZonvieConfig.shared.font.family.isEmpty ? "Menlo" : ZonvieConfig.shared.font.family
         let configSize = ZonvieConfig.shared.font.size > 0 ? ZonvieConfig.shared.font.size : 14.0
+        let familyExplicit = ZonvieConfig.shared.font.familyExplicit
+        let sizeExplicit = ZonvieConfig.shared.font.sizeExplicit
 
         // The payload may contain multiple newline-separated candidates
         // (guifont fallback list).  Try each in order; use the first
@@ -2257,30 +2271,36 @@ final class ZonvieCore {
         var features: String = ""
         var found = false
 
-        for candidate in candidates {
-            guard let parsed = Self.parseGuiFontEntry(String(candidate), configSize: configSize) else {
-                continue
+        // If the user explicitly set font.family in config.toml, skip guifont
+        // candidates entirely and go straight to the config fallback below.
+        if familyExplicit {
+            Self.appLog("[onGuiFont] family_explicit set, ignoring nvim guifont payload")
+        } else {
+            for candidate in candidates {
+                guard let parsed = Self.parseGuiFontEntry(String(candidate), configSize: configSize, sizeExplicit: sizeExplicit) else {
+                    continue
+                }
+                if Self.isFontAvailable(parsed.0) {
+                    name = parsed.0
+                    size = parsed.1
+                    features = parsed.2
+                    found = true
+                    Self.appLog("[onGuiFont] selected '\(name)' size=\(size) features='\(features)'")
+                    break
+                }
+                Self.appLog("[onGuiFont] skipped unavailable font '\(parsed.0)'")
             }
-            if Self.isFontAvailable(parsed.0) {
-                name = parsed.0
-                size = parsed.1
-                features = parsed.2
-                found = true
-                Self.appLog("[onGuiFont] selected '\(name)' size=\(size) features='\(features)'")
-                break
-            }
-            Self.appLog("[onGuiFont] skipped unavailable font '\(parsed.0)'")
-        }
 
-        // Single-entry payload (no newline) — use as-is even if not "available"
-        // to preserve backward compatibility with direct :set guifont=... usage.
-        if !found && candidates.count == 1 {
-            if let parsed = Self.parseGuiFontEntry(String(candidates[0]), configSize: configSize) {
-                name = parsed.0
-                size = parsed.1
-                features = parsed.2
-                found = true
-                Self.appLog("[onGuiFont] single candidate, using '\(name)' size=\(size)")
+            // Single-entry payload (no newline) — use as-is even if not "available"
+            // to preserve backward compatibility with direct :set guifont=... usage.
+            if !found && candidates.count == 1 {
+                if let parsed = Self.parseGuiFontEntry(String(candidates[0]), configSize: configSize, sizeExplicit: sizeExplicit) {
+                    name = parsed.0
+                    size = parsed.1
+                    features = parsed.2
+                    found = true
+                    Self.appLog("[onGuiFont] single candidate, using '\(name)' size=\(size)")
+                }
             }
         }
 

--- a/src/core/c_api.zig
+++ b/src/core/c_api.zig
@@ -1342,6 +1342,10 @@ pub const zonvie_config_values = extern struct {
     font_family: [*:0]const u8 = "",
     font_size: f32 = 14.0,
     font_linespace: i32 = 0,
+    // True when the user explicitly set [font] family / size in config.toml.
+    // Frontends should prefer config over nvim's default `guifont`.
+    font_family_explicit: bool = false,
+    font_size_explicit: bool = false,
     // window
     window_blur: bool = false,
     window_opacity: f32 = 1.0,
@@ -1414,6 +1418,8 @@ fn buildConfigValues(alloc: std.mem.Allocator, cfg: *const config.Config) zonvie
         .font_family = dupeZForC(alloc, cfg.font.family, "Menlo"),
         .font_size = cfg.font.size,
         .font_linespace = cfg.font.linespace,
+        .font_family_explicit = cfg.font.family_explicit,
+        .font_size_explicit = cfg.font.size_explicit,
         // window
         .window_blur = cfg.window.blur,
         .window_opacity = cfg.window.opacity,

--- a/src/core/c_api.zig
+++ b/src/core/c_api.zig
@@ -701,6 +701,21 @@ pub export fn zonvie_core_set_focus(p: ?*zonvie_core, gained: bool) callconv(.c)
     box.core.requestUiSetFocus(gained);
 }
 
+/// Set a global Neovim option value via `nvim_set_option_value`.
+/// Used by frontends to sync the effective `guifont` back to Neovim so
+/// `:set guifont?` reports what the frontend is actually rendering.
+pub export fn zonvie_core_set_option_value(
+    p: ?*zonvie_core,
+    name: [*]const u8,
+    name_len: usize,
+    value: [*]const u8,
+    value_len: usize,
+) callconv(.c) void {
+    if (p == null) return;
+    const box = asBox(p.?);
+    box.core.requestSetOptionValue(name[0..name_len], value[0..value_len]) catch {};
+}
+
 /// Send a Neovim command (via nvim_command API, does not show in cmdline)
 pub export fn zonvie_core_send_command(p: ?*zonvie_core, cmd: [*]const u8, len: usize) callconv(.c) void {
     if (p == null) return;

--- a/src/core/config.zig
+++ b/src/core/config.zig
@@ -168,6 +168,11 @@ pub const Config = struct {
         family: []const u8 = if (builtin.os.tag == .macos) "Menlo" else "Consolas",
         size: f32 = if (builtin.os.tag == .macos) 14.0 else 18.0,
         linespace: i32 = 0,
+        // Whether the user explicitly set the value in config.toml. When true,
+        // the frontend should prefer config over nvim's default `guifont`
+        // (which nvim sends at ui_attach even when the user hasn't set it).
+        family_explicit: bool = false,
+        size_explicit: bool = false,
     };
 
     pub const WindowConfig = struct {
@@ -323,8 +328,14 @@ pub const Config = struct {
         }
 
         if (cfg.font) |f| {
-            if (f.family) |fam| self.font.family = alloc.dupe(u8, fam) catch self.font.family;
-            if (f.size) |s| self.font.size = s;
+            if (f.family) |fam| {
+                self.font.family = alloc.dupe(u8, fam) catch self.font.family;
+                self.font.family_explicit = true;
+            }
+            if (f.size) |s| {
+                self.font.size = s;
+                self.font.size_explicit = true;
+            }
             if (f.linespace) |l| self.font.linespace = l;
         }
 

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -2501,6 +2501,27 @@ pub const Core = struct {
         self.log.write("rpc send: requestGlowConfig (id={d})\n", .{id});
     }
 
+    /// Set a global option value in Neovim via nvim_set_option_value.
+    /// Used e.g. to sync the effective `guifont` back to Neovim so `:set
+    /// guifont?` reports what the frontend is actually rendering.
+    pub fn requestSetOptionValue(self: *Core, name: []const u8, value: []const u8) !void {
+        const id = self.nextMsgId();
+        var buf: rpc.Buf = .empty;
+        defer buf.deinit(self.alloc);
+
+        try self.sendRequestHeader(&buf, id, "nvim_set_option_value");
+
+        // nvim_set_option_value(name, value, opts{}) — empty opts applies globally.
+        try rpc.packArray(&buf, self.alloc, 3);
+        try rpc.packStr(&buf, self.alloc, name);
+        try rpc.packStr(&buf, self.alloc, value);
+        try rpc.packMap(&buf, self.alloc, 0);
+
+        try self.sendRaw(buf.items);
+
+        self.log.write("rpc send: nvim_set_option_value {s}='{s}' (id={d})\n", .{ name, value, id });
+    }
+
     /// Execute Lua code in Neovim via nvim_exec_lua.
     pub fn requestExecLua(self: *Core, lua_code: []const u8) !void {
         const id = self.nextMsgId();

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -1395,6 +1395,24 @@ pub fn runLoop(self: *Core) void {
 
     self.log.write("[rpc] layout ready: rows={d} cols={d}, sending ui_attach\n", .{ self.ui_attach_rows, self.ui_attach_cols });
     self.requestSetClientInfo() catch |e| self.log.write("send set_client_info failed: {any}\n", .{e});
+
+    // If config.toml [font] family is set, push it to nvim's `guifont` BEFORE
+    // ui_attach. Sending it after ui_attach would arrive mid-redraw: nvim
+    // would emit an option_set during its initial paint, then re-emit after
+    // processing our set. The second paint round-trip caused the statusline
+    // to briefly drop its text on Windows at startup.
+    if (self.msg_config.font.family_explicit) {
+        var guifont_buf: [256]u8 = undefined;
+        const guifont_str = std.fmt.bufPrint(&guifont_buf, "{s}:h{d}", .{
+            self.msg_config.font.family,
+            self.msg_config.font.size,
+        }) catch null;
+        if (guifont_str) |val| {
+            self.requestSetOptionValue("guifont", val) catch |e|
+                self.log.write("pre-attach set guifont failed: {any}\n", .{e});
+        }
+    }
+
     self.requestUiAttach(self.ui_attach_rows, self.ui_attach_cols) catch |e| {
         self.log.write("ui_attach send failed: {any}\n", .{e});
         _ = child.kill() catch {};

--- a/windows/app.zig
+++ b/windows/app.zig
@@ -65,6 +65,7 @@ pub const zonvie_core_request_quit = core.zonvie_core_request_quit;
 pub const zonvie_core_quit_confirmed = core.zonvie_core_quit_confirmed;
 pub const zonvie_core_send_stdin_data = core.zonvie_core_send_stdin_data;
 pub const zonvie_core_send_command = core.zonvie_core_send_command;
+pub const zonvie_core_set_option_value = core.zonvie_core_set_option_value;
 pub const zonvie_core_set_background_opacity = core.zonvie_core_set_background_opacity;
 pub const zonvie_core_perf_now_ns = core.zonvie_core_perf_now_ns;
 pub const zonvie_core_note_input_trace = core.zonvie_core_note_input_trace;

--- a/windows/callbacks.zig
+++ b/windows/callbacks.zig
@@ -1962,13 +1962,25 @@ pub fn onLog(ctx: ?*anyopaque, bytes: [*c]const u8, len: usize) callconv(.c) voi
 pub fn onGuiFont(ctx: ?*anyopaque, bytes: ?[*]const u8, len: usize) callconv(.c) void {
     const app: *App = @ptrCast(@alignCast(ctx.?));
 
-    // Font priority: guifont > config.font.family > OS default (Consolas)
+    // Font priority:
+    //   1. config.font.family/size when explicitly set in config.toml
+    //   2. guifont payload from nvim
+    //   3. config.font defaults
+    //   4. OS default (Consolas)
+    //
+    // Nvim sends its own default guifont ("Cascadia Code,Cascadia Mono,...")
+    // on Windows at ui_attach time even when the user hasn't set one. Letting
+    // that default override an explicit config.toml [font] entry surprises
+    // users. If the user wants :set guifont=... to control the font, they
+    // should leave [font] out of config.toml.
     const os_default_font = "Consolas";
     const default_font_pt: f32 = 18.0;
 
     // Get config font (fallback to OS default if empty)
     const config_font = if (app.config.font.family.len > 0) app.config.font.family else os_default_font;
     const config_pt: f32 = if (app.config.font.size > 0.0) app.config.font.size else default_font_pt;
+    const family_explicit = app.config.font.family_explicit;
+    const size_explicit = app.config.font.size_explicit;
 
     // The payload may contain multiple newline-separated candidates
     // (guifont fallback list).  Try each in order; use the first font
@@ -1989,7 +2001,11 @@ pub fn onGuiFont(ctx: ?*anyopaque, bytes: ?[*]const u8, len: usize) callconv(.c)
         var applied_pt: f32 = config_pt;
         var font_set = false;
 
-        if (bytes != null and len != 0) {
+        // If the user explicitly set font.family in config.toml, skip guifont
+        // candidates entirely and go straight to the config fallback below.
+        const skip_guifont = family_explicit;
+
+        if (!skip_guifont and bytes != null and len != 0) {
             const s = bytes.?[0..len];
             // Iterate newline-separated candidates
             var line_it = std.mem.splitScalar(u8, s, '\n');
@@ -2007,10 +2023,10 @@ pub fn onGuiFont(ctx: ?*anyopaque, bytes: ?[*]const u8, len: usize) callconv(.c)
                         const size_str = after_name[0..tab2];
                         cand_features = after_name[tab2 + 1 ..];
                         const parsed_pt = std.fmt.parseFloat(f32, size_str) catch 0;
-                        cand_pt = if (parsed_pt > 0) parsed_pt else config_pt;
+                        cand_pt = if (size_explicit or parsed_pt <= 0) config_pt else parsed_pt;
                     } else {
                         const parsed_pt = std.fmt.parseFloat(f32, after_name) catch 0;
-                        cand_pt = if (parsed_pt > 0) parsed_pt else config_pt;
+                        cand_pt = if (size_explicit or parsed_pt <= 0) config_pt else parsed_pt;
                     }
                 } else {
                     continue; // no tab => skip invalid entry

--- a/windows/window.zig
+++ b/windows/window.zig
@@ -1731,8 +1731,16 @@ pub export fn WndProc(
                     updateLayoutToCore(hwnd, app);
                 }
 
-                // Unblock RPC thread once layout is known (before window is shown)
-                if (app.early_core_init_done and app.nvim_spawned and !shown) {
+                // Unblock RPC thread once layout is known (before window is shown).
+                // Guard: app.atlas must be set (done in WM_APP_DEFERRED_INIT) before
+                // unblocking. WM_SIZE fires synchronously during CreateWindowExW right
+                // after WM_CREATE, at which point early_atlas exists but app.atlas is
+                // still null. If we unblock here, onGuiFont fires with a null atlas and
+                // the configured font is silently dropped. WM_APP_DEFERRED_INIT sets
+                // app.atlas first and then calls notify_layout_ready; this WM_SIZE path
+                // only matters for subsequent WM_SIZE events that arrive with updated
+                // dimensions before the window is shown.
+                if (app.early_core_init_done and app.nvim_spawned and !shown and app.atlas != null) {
                     if (app.corep) |corep| {
                         if (app.surface.rows > 0 and app.surface.cols > 0) {
                             core.zonvie_core_notify_layout_ready(corep, app.surface.rows, app.surface.cols);


### PR DESCRIPTION
Fixed #2

Three related issues prevented config.toml [font] family/size from reaching the UI on Windows. The same priority inversion also existed on macOS and is fixed in this PR.

### Windows

1. Priority inversion in onGuiFont (primary cause of issue #2): Nvim sends a default `guifont` on Windows at ui_attach time ("Cascadia Code,Cascadia Mono,Consolas,Courier New,monospace") even when the user has not set one. The previous "guifont > config > OS default" priority silently replaced the explicit config.toml entry with nvim's default list. Track whether the user actually set font.family / font.size in config.toml (family_explicit / size_explicit) and, when set, skip guifont candidates so config wins. `:set guifont=...` continues to work for users who leave [font] out of config.toml.

2. `:set guifont?` reported nvim's value, not what zonvie rendered: Overriding the font frontend-side left Neovim's internal `guifont` unchanged, so `:set guifont?` showed the fallback list. Push `guifont=<family>:h<size>` to nvim via a new `nvim_set_option_value` RPC (`zonvie_core_set_option_value` C ABI) **before `nvim_ui_attach`** so nvim's initial paint uses the config font from the start. Sending after ui_attach would arrive mid-redraw — nvim would emit an `option_set` during its initial paint, then re-emit after processing our set — and the second paint round-trip caused the statusline text to briefly drop on Windows at startup (resizing forced a re-seed that restored it).

3. WM_SIZE race with WM_APP_DEFERRED_INIT: WM_SIZE fires synchronously during CreateWindowExW right after WM_CREATE, before WM_APP_DEFERRED_INIT runs. At that point early_atlas exists but app.atlas is still null. The unguarded WM_SIZE path unblocked the RPC thread early, so onGuiFont fired with a null atlas and silently dropped the font anyway. Add `app.atlas != null` to the guard so notify_layout_ready is only called from WM_SIZE once app.atlas is set; WM_APP_DEFERRED_INIT remains the canonical first unblock point.

In v0.3.14 the race in (3) masked (1): onGuiFont saw a null atlas and did nothing, leaving the initMetrics-loaded config font in place. The v0.3.15 two-phase init eliminated that race, which exposed the underlying priority bug.

### macOS

4. Same priority inversion in macOS `onGuiFont`: The macOS frontend had the same bug as Windows — nvim's default `guifont` at ui_attach silently overrode an explicit config.toml [font] entry. Expose the `family_explicit` / `size_explicit` flags from (1) through the `zonvie_config_values` C ABI, propagate them into `ZonvieConfig.FontConfig`, and mirror the Windows logic in `ZonvieCore.onGuiFont`: when `family_explicit` is true, skip the nvim guifont candidates entirely and fall through to the config font; when `size_explicit` is true, ignore parsed sizes and use the config size.

The `nvim_set_option_value` push from (2) lives in shared core code (`src/core/rpc_session.zig`), so it already covers macOS — no macOS-specific change is needed there.