### PR TITLE
fix(windows): preserve atlas state across D2D context re-init (#4)

### DIFF
--- a/windows/renderer/dwrite_d2d_renderer.zig
+++ b/windows/renderer/dwrite_d2d_renderer.zig
@@ -500,11 +500,19 @@ pub const Renderer = struct {
         safeRelease(self.solid_brush);
         self.solid_brush = null;
 
-        self.glyph_map.clearRetainingCapacity();
-        self.styled_glyph_map.clearRetainingCapacity();
-        self.atlas_next_x = 1;
-        self.atlas_next_y = 1;
-        self.atlas_row_h = 0;
+        // Preserve already-rasterized glyph state when atlas_cpu is already
+        // sized (i.e. createAtlasResources is being re-entered, e.g. from a
+        // deferred initD2DDeviceContext after the first flush started).
+        // Resetting packer/glyph_map here would orphan pixels still sitting
+        // in atlas_cpu for vertices that have already been emitted.
+        const cpu_total = @as(usize, self.atlas_w) * @as(usize, self.atlas_h) * 4;
+        if (self.atlas_cpu.items.len != cpu_total) {
+            self.glyph_map.clearRetainingCapacity();
+            self.styled_glyph_map.clearRetainingCapacity();
+            self.atlas_next_x = 1;
+            self.atlas_next_y = 1;
+            self.atlas_row_h = 0;
+        }
 
         // RGBA format for true ClearType subpixel rendering
         const props = c.D2D1_BITMAP_PROPERTIES{
@@ -569,13 +577,17 @@ pub const Renderer = struct {
             self.solid_brush = null;
         }
 
-        // 4 bytes per pixel (RGBA) for true ClearType subpixel rendering
-        const total = @as(usize, self.atlas_w) * @as(usize, self.atlas_h) * 4;
-        try self.atlas_cpu.resize(self.alloc, total);
-        @memset(self.atlas_cpu.items, 0);
-
-        self.pending_upload_base_seq += self.pending_uploads.items.len;
-        self.pending_uploads.clearRetainingCapacity();
+        // 4 bytes per pixel (RGBA) for true ClearType subpixel rendering.
+        // Only zero atlas_cpu and drop pending_uploads when the backing
+        // buffer was (re)allocated; preserving both is critical when this
+        // runs mid-flush (see note above and issue #4).
+        const was_sized = (self.atlas_cpu.items.len == cpu_total);
+        try self.atlas_cpu.resize(self.alloc, cpu_total);
+        if (!was_sized) {
+            @memset(self.atlas_cpu.items, 0);
+            self.pending_upload_base_seq += self.pending_uploads.items.len;
+            self.pending_uploads.clearRetainingCapacity();
+        }
 
         const bmp_ptr = self.atlas_bitmap orelse return error.CreateAtlasFailed;
         const bvtbl = bmp_ptr.lpVtbl.*;


### PR DESCRIPTION
fixed #4 

The D2D device context is initialized lazily in WM_APP_DEFERRED_INIT after the D3D11 device is ready on a worker thread. By the time it runs, the RPC thread may already be mid-flush: glyphs have been rasterized and their pixels written into atlas_cpu, vertices have been emitted referring to those uv positions, and pending_uploads records the dirty rects.

createAtlasResources used to unconditionally:
  - clear glyph_map / styled_glyph_map
  - reset the shelf packer (atlas_next_x/y, atlas_row_h)
  - resize+@memset(atlas_cpu, 0)
  - drop pending_uploads (bump base_seq and clear)

Running this mid-flush orphans every previously-rasterized glyph: atlas_cpu loses the pixels, the packer forgets it ever allocated those slots, the pending dirty-rect queue is thrown away, and the first WM_PAINT full upload ships a buffer where the first wave of glyphs is all zeros. Vertices still point at the uv slots where those glyphs used to live, so the GPU samples zero alpha for them and the cells go blank. The surviving glyphs that get rasterized after the D2D init runs render fine, which matches the intermittent "specific characters missing" symptom in issue #4.

Skip the resets when atlas_cpu is already sized to the current atlas_w*atlas_h*4: that only happens on re-entry into createAtlasResources, and the existing atlas_cpu / packer / pending state is still the authoritative source. CopyFromMemory right below still pushes atlas_cpu into the freshly-created D2D bitmap, so the D2D path stays in sync too. First-time initialization (len == 0) and genuine size changes take the original reset path.