### PR TITLE
feat(windows): use CW_USEDEFAULT for initial window size

### DIFF
--- a/macos/Sources/App/AppDelegate.swift
+++ b/macos/Sources/App/AppDelegate.swift
@@ -171,19 +171,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
         win.contentMinSize = NSSize(width: minWidth, height: 300)
 
+        // Assign the content view controller BEFORE restoring the frame.
+        // NSWindow.contentViewController setter resizes the window to match
+        // the view controller's view contentSize (~400x300 default), which
+        // would otherwise overwrite a restored autosave frame.
+        let vc = ViewController()
+        win.contentViewController = vc
+
         // Persist/restore window geometry (AppKit feature).
         win.setFrameAutosaveName(windowFrameAutosaveName)
 
         // If there is a saved frame from the last session, use it.
         // Otherwise keep the computed default rect (centered 800x600-ish).
-        if win.setFrameUsingName(windowFrameAutosaveName) {
-            // Restored from the last session; do not recenter.
-        } else {
+        if !win.setFrameUsingName(windowFrameAutosaveName) {
             win.center()
         }
-
-        let vc = ViewController()
-        win.contentViewController = vc
 
         self.window = win
         win.delegate = self  // Handle window close with unsaved buffer check

--- a/macos/Sources/App/main.swift
+++ b/macos/Sources/App/main.swift
@@ -471,5 +471,9 @@ app.run()
 // Exit with Neovim's exit code (only meaningful in --nofork mode)
 // In fork mode, the parent process already exited with 0, so child's exit code
 // is not visible to the terminal.
+// Force any pending UserDefaults writes (e.g. NSWindow frame autosave) to
+// disk before Darwin.exit kills the process — the C exit() path skips
+// cfprefsd's natural drain that NSApp.terminate() would otherwise allow.
+UserDefaults.standard.synchronize()
 Darwin.exit(ZonvieCore.getExitCode())
 

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -2573,7 +2573,15 @@ final class ZonvieCore {
         // NSApp.terminate() would call exit(0) internally, losing the code.
         // Darwin.exit() directly would skip AppKit teardown and crash when
         // DispatchSemaphore is disposed mid-wait (MTKView inflightSemaphore).
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            // Force-flush the main window's frame to UserDefaults before the
+            // run loop stops. setFrameAutosaveName auto-saves on resize but
+            // those writes are in-memory; the main.swift Darwin.exit path
+            // bypasses AppKit's natural shutdown flush, so an explicit save
+            // here is needed to persist the most recent geometry.
+            if let win = self?.terminalView?.window, !win.frameAutosaveName.isEmpty {
+                win.saveFrame(usingName: win.frameAutosaveName)
+            }
             NSApp.stop(nil)
             // NSApp.stop requires a pending event to actually break the loop
             let event = NSEvent.otherEvent(

--- a/windows/main.zig
+++ b/windows/main.zig
@@ -631,7 +631,7 @@ pub fn main() u8 {
         @ptrCast(title.ptr),
         window_style,
         c.CW_USEDEFAULT, c.CW_USEDEFAULT,
-        1000, 700,
+        c.CW_USEDEFAULT, c.CW_USEDEFAULT,
         null, null,
         wc.hInstance,
         app, // lpParam -> WM_NCCREATE


### PR DESCRIPTION
Fixed #8 

Windows:

- Replace the hardcoded `1000, 700` initial size with `CW_USEDEFAULT, CW_USEDEFAULT` so the OS picks an initial size based on the placement monitor's work area, restoring a reasonable first-run experience on high-DPI and 4K displays.
- Per-Monitor V2 DPI awareness is already enabled before `CreateWindowExW`, so the default is interpreted at the placement monitor's DPI on mixed-DPI setups.
- External grid windows (`windows/ui/external_windows.zig`) are intentionally left unchanged; their geometry is driven by Neovim grid coordinates, not OS defaults.

macOS: also restore the saved window frame across launches

- Move the NSWindow.contentViewController = vc assignment ahead of setFrameAutosaveName / setFrameUsingName; the setter resizes the window to the view controller's view contentSize (~400×300), which silently overwrote the restored autosave frame, leaving every launch at the minimum size.
- Save the main window frame explicitly in onExitFromNvim before NSApp.stop, and call UserDefaults.standard.synchronize() before Darwin.exit in main.swift; zonvie quits via NSApp.stop + Darwin.exit to preserve Neovim's exit code, which skips the cfprefsd drain that NSApp.terminate would otherwise grant, so AppKit's deferred autosave writes were occasionally lost.
- External grid windows are intentionally left unchanged; they don't use frame autosave.
