### PR TITLE
fix(windows): pair UTF-16 surrogates in WM_CHAR / WM_IME_CHAR

### DIFF
--- a/windows/app.zig
+++ b/windows/app.zig
@@ -2598,6 +2598,15 @@ pub const App = struct {
     ime_target_end: u32 = 0, // end of target clause
     ime_overlay_hwnd: ?c.HWND = null, // Layered window for preedit overlay
 
+    // Pending UTF-16 high surrogate from a previous WM_CHAR / WM_IME_CHAR.
+    // Windows delivers a non-BMP character (e.g. emoji) as two consecutive
+    // messages: high surrogate first, then low surrogate. We buffer the high
+    // surrogate here and combine it with the next low surrogate to form one
+    // UTF-8 sequence to send to core. Stored separately for WM_CHAR vs.
+    // WM_IME_CHAR because they can interleave around composition. 0 = none.
+    pending_high_surrogate_char: u16 = 0,
+    pending_high_surrogate_ime: u16 = 0,
+
     // When row-mode starts (or after resize), we must seed the persistent back buffer once.
     // Otherwise the first present may clear to black and only the dirty row gets drawn.
     need_full_seed: std.atomic.Value(bool) = std.atomic.Value(bool).init(true),

--- a/windows/ui/external_windows.zig
+++ b/windows/ui/external_windows.zig
@@ -1392,17 +1392,28 @@ pub export fn ExternalWndProc(
 
                 // Skip control characters handled by WM_KEYDOWN
                 if (ch0 == 0x08 or ch0 == 0x09 or ch0 == 0x0D or ch0 == 0x1B) {
+                    app.pending_high_surrogate_char = 0;
                     return 0;
                 }
 
-                // Skip surrogates for now
-                if (ch0 >= 0xD800 and ch0 <= 0xDFFF) {
-                    return 0;
-                }
-
+                // Pair surrogate halves for non-BMP characters (emoji etc).
                 var tmp: [8]u8 = undefined;
-                if (input.utf16UnitsToUtf8(&tmp, ch0, null)) |s| {
-                    input.sendKeyEventToCore(app, 0, mods, s, null);
+                var s: ?[]const u8 = null;
+                if (ch0 >= 0xD800 and ch0 <= 0xDBFF) {
+                    app.pending_high_surrogate_char = ch0;
+                    return 0;
+                } else if (ch0 >= 0xDC00 and ch0 <= 0xDFFF) {
+                    const hi = app.pending_high_surrogate_char;
+                    app.pending_high_surrogate_char = 0;
+                    if (hi == 0) return 0;
+                    s = input.utf16UnitsToUtf8(&tmp, hi, ch0);
+                } else {
+                    app.pending_high_surrogate_char = 0;
+                    s = input.utf16UnitsToUtf8(&tmp, ch0, null);
+                }
+
+                if (s) |text| {
+                    input.sendKeyEventToCore(app, 0, mods, text, null);
                 }
                 return 0;
             }
@@ -1813,20 +1824,29 @@ pub export fn ExternalWndProc(
         },
 
         c.WM_IME_CHAR => {
-            // IME committed character - send to Neovim
+            // IME committed character - send to Neovim. Non-BMP commits arrive
+            // as two consecutive WM_IME_CHAR messages (high then low surrogate).
             if (applog.isEnabled()) applog.appLog("[IME][ext] WM_IME_CHAR wParam=0x{x}\n", .{wParam});
             if (app_mod.getApp(hwnd)) |app| {
                 const ch: u16 = @intCast(wParam);
 
-                // Skip surrogate pairs for now
-                if (ch >= 0xD800 and ch <= 0xDFFF) {
+                var out: [8]u8 = undefined;
+                var s: ?[]const u8 = null;
+                if (ch >= 0xD800 and ch <= 0xDBFF) {
+                    app.pending_high_surrogate_ime = ch;
                     return 0;
+                } else if (ch >= 0xDC00 and ch <= 0xDFFF) {
+                    const hi = app.pending_high_surrogate_ime;
+                    app.pending_high_surrogate_ime = 0;
+                    if (hi == 0) return 0;
+                    s = input.utf16UnitsToUtf8(&out, hi, ch);
+                } else {
+                    app.pending_high_surrogate_ime = 0;
+                    s = input.utf16UnitsToUtf8(&out, ch, null);
                 }
 
-                var out: [8]u8 = undefined;
-                const s = input.utf16UnitsToUtf8(&out, ch, null) orelse return 0;
-
-                input.sendKeyEventToCore(app, 0, 0, s, s);
+                const text = s orelse return 0;
+                input.sendKeyEventToCore(app, 0, 0, text, text);
                 return 0;
             }
         },

--- a/windows/window.zig
+++ b/windows/window.zig
@@ -2999,23 +2999,31 @@ pub export fn WndProc(
                 // This prevents double-input of Enter, Backspace, Tab, Escape.
                 // 0x08 = Backspace, 0x09 = Tab, 0x0D = Enter (CR), 0x1B = Escape
                 if (ch0 == 0x08 or ch0 == 0x09 or ch0 == 0x0D or ch0 == 0x1B) {
+                    app.pending_high_surrogate_char = 0;
                     return 0;
                 }
 
-                // WM_CHAR gives UTF-16 code unit; handle surrogate pair minimally:
-                // If high surrogate, wait for next WM_CHAR is complex; for now ignore high surrogate.
-                if (ch0 >= 0xD800 and ch0 <= 0xDBFF) {
-                    return 0;
-                }
-                if (ch0 >= 0xDC00 and ch0 <= 0xDFFF) {
-                    return 0;
-                }
-
+                // Non-BMP characters (e.g. emoji) arrive as two WM_CHARs: high
+                // surrogate first, then low surrogate. Buffer the high one and
+                // combine it with the next low one before sending to core.
                 var out: [8]u8 = undefined;
-                const s = input.utf16UnitsToUtf8(&out, ch0, null) orelse return 0;
+                var s: ?[]const u8 = null;
+                if (ch0 >= 0xD800 and ch0 <= 0xDBFF) {
+                    app.pending_high_surrogate_char = ch0;
+                    return 0;
+                } else if (ch0 >= 0xDC00 and ch0 <= 0xDFFF) {
+                    const hi = app.pending_high_surrogate_char;
+                    app.pending_high_surrogate_char = 0;
+                    if (hi == 0) return 0; // stray low surrogate
+                    s = input.utf16UnitsToUtf8(&out, hi, ch0);
+                } else {
+                    app.pending_high_surrogate_char = 0;
+                    s = input.utf16UnitsToUtf8(&out, ch0, null);
+                }
 
+                const text = s orelse return 0;
                 // keycode=0 means "text input" (Zig will take chars path).
-                input.sendKeyEventToCore(app, 0, mods, s, s);
+                input.sendKeyEventToCore(app, 0, mods, text, text);
                 return 0;
             }
         },
@@ -3170,19 +3178,28 @@ pub export fn WndProc(
         },
 
         c.WM_IME_CHAR => {
-            // IME committed character - send to Neovim
+            // IME committed character - send to Neovim. Non-BMP commits arrive
+            // as two consecutive WM_IME_CHAR messages (high then low surrogate).
             if (getApp(hwnd)) |app| {
                 const ch: u16 = @intCast(wParam);
 
-                // Skip surrogate pairs for now (complex handling)
-                if (ch >= 0xD800 and ch <= 0xDFFF) {
+                var out: [8]u8 = undefined;
+                var s: ?[]const u8 = null;
+                if (ch >= 0xD800 and ch <= 0xDBFF) {
+                    app.pending_high_surrogate_ime = ch;
                     return 0;
+                } else if (ch >= 0xDC00 and ch <= 0xDFFF) {
+                    const hi = app.pending_high_surrogate_ime;
+                    app.pending_high_surrogate_ime = 0;
+                    if (hi == 0) return 0;
+                    s = input.utf16UnitsToUtf8(&out, hi, ch);
+                } else {
+                    app.pending_high_surrogate_ime = 0;
+                    s = input.utf16UnitsToUtf8(&out, ch, null);
                 }
 
-                var out: [8]u8 = undefined;
-                const s = input.utf16UnitsToUtf8(&out, ch, null) orelse return 0;
-
-                input.sendKeyEventToCore(app, 0, 0, s, s);
+                const text = s orelse return 0;
+                input.sendKeyEventToCore(app, 0, 0, text, text);
                 return 0;
             }
         },


### PR DESCRIPTION
Fixed #10 

Win32 delivers non-BMP characters as two consecutive messages (high then low surrogate). The handlers dropped both halves, so emoji input via the picker or IME was silently lost. Buffer the high surrogate and combine it with the next low surrogate before forwarding to core.


https://github.com/user-attachments/assets/643c8751-1fa3-49eb-94d4-b07154c14995

