### PR TITLE
feat(rpc): support nvim restart/connect UI events

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ zonvie [OPTIONS] [--] [NVIM_ARGS...]
 | `--devcontainer=<workspace>` | Run inside a devcontainer |
 | `--devcontainer-config=<path>` | Path to devcontainer.json |
 | `--devcontainer-rebuild` | Rebuild devcontainer before starting |
+| `--connect-nvim=<addr>` | Attach to a running Neovim server (TCP `host:port` or Unix socket path). Mutually exclusive with `--ssh` / `--devcontainer` / `--wsl`. |
+| `--remote-ui=<addr>` | Alias of `--connect-nvim`, mirrors `nvim --remote-ui` |
 | `--install` | Create default config file and exit |
 | `--` | Pass all remaining arguments to nvim |
 | `--help`, `-h` | Show help message |
@@ -89,6 +91,11 @@ zonvie --ssh=user@example.com
 
 # Run in devcontainer
 zonvie --devcontainer=/path/to/project
+
+# Attach to a Neovim server already running (e.g. started elsewhere with
+# `nvim --headless --listen /tmp/nvim.sock` or `:detach`'d from another UI)
+zonvie --connect-nvim=/tmp/nvim.sock
+zonvie --connect-nvim=127.0.0.1:6789
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ zonvie [OPTIONS] [--] [NVIM_ARGS...]
 | `--devcontainer=<workspace>` | Run inside a devcontainer |
 | `--devcontainer-config=<path>` | Path to devcontainer.json |
 | `--devcontainer-rebuild` | Rebuild devcontainer before starting |
-| `--connect-nvim=<addr>` | Attach to a running Neovim server (TCP `host:port` or Unix socket path). Mutually exclusive with `--ssh` / `--devcontainer` / `--wsl`. |
+| `--connect-nvim=<addr>` | Attach to a running Neovim server. Address: POSIX (macOS/Linux) — TCP `host:port` or Unix socket path; Windows — named pipe path (e.g. `\\.\pipe\nvim.31920.0`). Mutually exclusive with `--ssh` / `--devcontainer` / `--wsl`. |
 | `--remote-ui=<addr>` | Alias of `--connect-nvim`, mirrors `nvim --remote-ui` |
 | `--install` | Create default config file and exit |
 | `--` | Pass all remaining arguments to nvim |
@@ -94,8 +94,9 @@ zonvie --devcontainer=/path/to/project
 
 # Attach to a Neovim server already running (e.g. started elsewhere with
 # `nvim --headless --listen /tmp/nvim.sock` or `:detach`'d from another UI)
-zonvie --connect-nvim=/tmp/nvim.sock
-zonvie --connect-nvim=127.0.0.1:6789
+zonvie --connect-nvim=/tmp/nvim.sock          # POSIX: Unix socket
+zonvie --connect-nvim=127.0.0.1:6789          # POSIX: TCP
+zonvie --connect-nvim=\\.\pipe\nvim.31920.0  # Windows: named pipe
 ```
 
 ## Configuration

--- a/build.zig
+++ b/build.zig
@@ -209,6 +209,17 @@ pub fn build(b: *std.Build) !void {
     });
     test_step.dependOn(&b.addRunArtifact(mpack_stream_tests).step);
 
+    // RPC transport address-parser tests (inline tests in src/core/rpc_transport.zig).
+    const rpc_transport_test_mod = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .root_source_file = b.path("src/core/rpc_transport.zig"),
+    });
+    const rpc_transport_tests = b.addTest(.{
+        .root_module = rpc_transport_test_mod,
+    });
+    test_step.dependOn(&b.addRunArtifact(rpc_transport_tests).step);
+
     // Shader cross-compile tests (inline tests in src/core/shader_compiler.zig).
     // Requires glslang + SPIRV-Cross linked.
     const shader_test_mod = b.createModule(.{

--- a/include/zonvie_core.h
+++ b/include/zonvie_core.h
@@ -832,12 +832,20 @@ void zonvie_core_destroy(zonvie_core *core);
 int  zonvie_core_start(zonvie_core *core, const char *nvim_path, unsigned rows, unsigned cols);
 
 /* Start in connect mode: attach to a running Neovim server at
-   `listen_addr` (TCP "host:port" or Unix socket path) instead of
-   spawning a child. Same lifecycle and callbacks as `zonvie_core_start`;
-   the only difference is the initial transport.
+   `listen_addr` instead of spawning a child. Same lifecycle and
+   callbacks as `zonvie_core_start`; the only difference is the
+   initial transport.
+
+   Address formats by platform:
+       POSIX (macOS, Linux): TCP "host:port" or Unix socket path
+       Windows:              named pipe path, e.g. "\\\\.\\pipe\\nvim.31920.0"
+                             (TCP and Unix sockets are not yet supported)
+
    Returns 0 on success, negative on error:
        -1 invalid handle, -2 thread spawn failed, -3 invalid address.
-   Windows named pipes are not yet supported. */
+   Address validity is checked synchronously: parse failures and
+   platform-unsupported forms (e.g. TCP on Windows) return -3 before
+   the run loop is started. */
 int  zonvie_core_start_connect(
     zonvie_core *core,
     const uint8_t *listen_addr, size_t listen_addr_len,

--- a/include/zonvie_core.h
+++ b/include/zonvie_core.h
@@ -283,6 +283,27 @@ typedef void (*zonvie_on_set_title_fn)(
     const uint8_t* title, size_t title_len
 );
 
+/* Called when Neovim sends the `restart` UI event (`:restart` command).
+   listen_addr is the new server's listen address (TCP host:port or
+   Unix socket path). Informational only — the core handles the actual
+   reconnect; the frontend MUST NOT close its window or treat this as
+   `on_exit`. The matching `on_exit` will not fire for this transition. */
+typedef void (*zonvie_on_restart_fn)(
+    void* ctx,
+    const uint8_t* listen_addr, size_t listen_addr_len
+);
+
+/* Called when Neovim sends the `connect` UI event (`:connect <addr>`).
+   server_addr is the address the UI is being hot-swapped to. Same
+   reconnect semantics as `on_restart`; the only difference is that the
+   previous server keeps running headless instead of dying. The frontend
+   may use this to distinguish hot-swap (`:connect`) from server
+   replacement (`:restart`) for logging or status display. */
+typedef void (*zonvie_on_connect_fn)(
+    void* ctx,
+    const uint8_t* server_addr, size_t server_addr_len
+);
+
 /* Called when a grid should be displayed in an external window.
    grid_id: the grid to display externally
    win: Neovim window handle (for reference)
@@ -738,6 +759,15 @@ typedef struct zonvie_callbacks {
        Suppressed when multiple scrolls occur in the same batch.
        Consumer must validate eligibility before applying optimizations. */
     zonvie_on_grid_row_scroll_fn on_grid_row_scroll;
+
+    /* Restart UI event observer (informational; core handles reconnect).
+       Appended at the end of the struct to preserve ABI for older callers
+       that pass a smaller callbacks_size to zonvie_core_create. */
+    zonvie_on_restart_fn on_restart;
+
+    /* Connect UI event observer (informational; core handles reconnect).
+       Appended after on_restart for the same ABI-compat reason. */
+    zonvie_on_connect_fn on_connect;
 } zonvie_callbacks;
 
 void zonvie_core_set_log_enabled(zonvie_core *core, int enabled);
@@ -800,6 +830,19 @@ zonvie_core *zonvie_core_create(zonvie_callbacks *cb, size_t callbacks_size, voi
 void zonvie_core_destroy(zonvie_core *core);
 
 int  zonvie_core_start(zonvie_core *core, const char *nvim_path, unsigned rows, unsigned cols);
+
+/* Start in connect mode: attach to a running Neovim server at
+   `listen_addr` (TCP "host:port" or Unix socket path) instead of
+   spawning a child. Same lifecycle and callbacks as `zonvie_core_start`;
+   the only difference is the initial transport.
+   Returns 0 on success, negative on error:
+       -1 invalid handle, -2 thread spawn failed, -3 invalid address.
+   Windows named pipes are not yet supported. */
+int  zonvie_core_start_connect(
+    zonvie_core *core,
+    const uint8_t *listen_addr, size_t listen_addr_len,
+    unsigned rows, unsigned cols);
+
 void zonvie_core_stop(zonvie_core *core);
 
 /* Notify the core that actual layout dimensions are ready.

--- a/macos/Sources/App/ViewController.swift
+++ b/macos/Sources/App/ViewController.swift
@@ -118,13 +118,51 @@ final class ViewController: NSViewController {
         if sshEnabled || devcontainerModeEnabled {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
-                _ = self.core.start(nvimPath: nvimPath, rows: 1, cols: 1)
+                let rc = self.core.start(nvimPath: nvimPath, rows: 1, cols: 1)
+                if rc != 0 { self.handleCoreStartFailure(rc: rc, context: "ssh/devcontainer") }
             }
         } else {
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let self = self else { return }
-                _ = self.core.start(nvimPath: nvimPath, rows: 1, cols: 1)
+                let rc = self.core.start(nvimPath: nvimPath, rows: 1, cols: 1)
+                if rc != 0 { self.handleCoreStartFailure(rc: rc, context: "native") }
             }
+        }
+    }
+
+    /// Surface a synchronous start() / start_connect() failure to the user
+    /// and terminate. The C ABI returns 0 on success, -1 invalid handle,
+    /// -2 thread spawn failed, -3 invalid/unsupported listen address. In
+    /// every failure case the core thread did NOT start and on_exit will
+    /// not fire, so without explicit handling the window would remain
+    /// open with no backing nvim — the user sees an empty zombie window.
+    private func handleCoreStartFailure(rc: Int32, context: String) {
+        ZonvieCore.appLog("[start] core start failed rc=\(rc) context=\(context); terminating")
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.messageText = "Zonvie failed to start"
+            let reason: String
+            switch rc {
+            case -1: reason = "Invalid core handle (rc=-1)."
+            case -2: reason = "Could not spawn the RPC run-loop thread (rc=-2)."
+            case -3: reason = "Invalid or unsupported listen address (rc=-3). For --connect-nvim, use a TCP \"host:port\" or absolute Unix-socket path on macOS."
+            default: reason = "Unknown error (rc=\(rc))."
+            }
+            alert.informativeText = "\(reason)\nContext: \(context)."
+            alert.alertStyle = .critical
+            alert.addButton(withTitle: "Quit")
+            _ = alert.runModal()
+            // Use Darwin.exit(1) instead of NSApp.terminate(nil) so the
+            // shell sees a non-zero exit code for fatal startup failures.
+            // NSApp.terminate(nil) runs the normal AppKit teardown and
+            // returns 0, which would mask the failure for callers
+            // scripting around `zonvie --connect-nvim=...`. The specific
+            // failure reason (rc value, context) is surfaced via the
+            // NSAlert text above, not via the exit code — exit codes are
+            // a binary success/failure signal, matching the rest of
+            // zonvie's CLI validation paths.
+            ZonvieCore.appLog("[start] handleCoreStartFailure: exit(1)")
+            Darwin.exit(1)
         }
     }
 

--- a/macos/Sources/App/main.swift
+++ b/macos/Sources/App/main.swift
@@ -404,6 +404,22 @@ if !noforkMode && !launchedFromFinder {
         print("Warning: Cannot determine HOME directory, running without fork")
     }
 
+    // --connect-nvim / --remote-ui: never fork. The fork pattern below has
+    // the parent exit(0) immediately after a successful posix_spawnp,
+    // before the child has had a chance to run zonvie_core_start_connect
+    // (which can fail synchronously with rc=-3) or fire on_exit(1) from
+    // a hot-swap connect failure. With fork, those failures resolve
+    // entirely inside a child whose stdio is /dev/null and whose exit
+    // code never reaches the parent shell — a script wrapping
+    // `zonvie --connect-nvim=...` would see exit 0 even on failure.
+    // Foregrounding restores the contract that ViewController.swift
+    // handleCoreStartFailure already assumes ("the shell sees a non-
+    // zero exit code"). For the common case (terminal launch with no
+    // connect mode) the fork still applies.
+    if connectModeEnabled {
+        shouldFork = false
+    }
+
     if shouldFork {
         // Use posix_spawnp instead of fork to avoid macOS GUI/IME issues after fork.
         // fork() breaks WindowServer/HIToolbox connections needed for IME candidate windows.

--- a/macos/Sources/App/main.swift
+++ b/macos/Sources/App/main.swift
@@ -19,6 +19,7 @@ let devcontainerModeEnabled = args.contains { $0.hasPrefix("--devcontainer=") ||
 //   --nofork, --nvim <path>, --log <path>, --extcmdline, --extpopup, --extpopupmenu,
 //   --extmessages, --exttabline, --extwindows, --ssh=*, --ssh-identity=*,
 //   --devcontainer=*, --devcontainer-config=*, --devcontainer-rebuild,
+//   --connect-nvim=*, --remote-ui=* (alias),
 //   --help, -h
 // After "--", all remaining arguments are passed to nvim
 var cliNvimPath: String? = nil
@@ -63,11 +64,13 @@ do {
             // Skip --log and its value
             i += 2
         } else if arg == "--ssh" || arg == "--ssh-identity" ||
-                  arg == "--devcontainer" || arg == "--devcontainer-config" {
+                  arg == "--devcontainer" || arg == "--devcontainer-config" ||
+                  arg == "--connect-nvim" || arg == "--remote-ui" {
             // Skip space-separated value arguments (--ssh host, --devcontainer path, etc.)
             i += 2
         } else if arg.hasPrefix("--ssh=") || arg.hasPrefix("--ssh-identity=") ||
-                  arg.hasPrefix("--devcontainer=") || arg.hasPrefix("--devcontainer-config=") {
+                  arg.hasPrefix("--devcontainer=") || arg.hasPrefix("--devcontainer-config=") ||
+                  arg.hasPrefix("--connect-nvim=") || arg.hasPrefix("--remote-ui=") {
             // Skip =value style arguments
             i += 1
         } else {
@@ -144,6 +147,10 @@ if args.contains("--help") || args.contains("-h") {
             --devcontainer=<workspace>    Run inside a devcontainer
             --devcontainer-config=<path>  Path to devcontainer.json
             --devcontainer-rebuild        Rebuild devcontainer before starting
+            --connect-nvim=<addr>         Attach to a running Neovim server.
+                                            Address: TCP "host:port" or Unix socket path.
+                                            Mutually exclusive with --ssh / --devcontainer.
+            --remote-ui=<addr>            Alias of --connect-nvim, mirrors `nvim --remote-ui`.
             --install                     Create default config file and exit
             --help, -h                    Show this help message and exit
             --                            Pass all remaining arguments to nvim

--- a/macos/Sources/App/main.swift
+++ b/macos/Sources/App/main.swift
@@ -8,11 +8,23 @@ signal(SIGPIPE, SIG_IGN)
 
 // Check for --nofork and --help early (before any other processing)
 let args = CommandLine.arguments
-let noforkMode = args.contains("--nofork")
+
+// `zonvieArgs` is the argv slice up to (but not including) the first `--`.
+// Anything after `--` is forwarded verbatim to nvim and must NOT be parsed
+// as a zonvie option, otherwise `zonvie -- --ssh=...` would erroneously
+// flip on SSH mode (and similar for --connect-nvim, --devcontainer, etc.).
+let zonvieArgs: [String] = {
+    if let sep = args.firstIndex(of: "--") {
+        return Array(args[..<sep])
+    }
+    return args
+}()
+
+let noforkMode = zonvieArgs.contains("--nofork")
 
 // Check if SSH or devcontainer mode (window should be hidden until auth completes)
-let sshModeEnabled = args.contains { $0.hasPrefix("--ssh=") || $0 == "--ssh" }
-let devcontainerModeEnabled = args.contains { $0.hasPrefix("--devcontainer=") || $0 == "--devcontainer" }
+let sshModeEnabled = zonvieArgs.contains { $0.hasPrefix("--ssh=") || $0 == "--ssh" }
+let devcontainerModeEnabled = zonvieArgs.contains { $0.hasPrefix("--devcontainer=") || $0 == "--devcontainer" }
 
 // Collect arguments that are NOT zonvie-specific (these will be passed to nvim)
 // zonvie-specific arguments:
@@ -125,8 +137,10 @@ func loadShellEnvironment() {
     }
 }
 
-// Handle --help before fork (so output goes to terminal)
-if args.contains("--help") || args.contains("-h") {
+// Handle --help before fork (so output goes to terminal).
+// Use zonvieArgs so `zonvie -- --help` forwards `--help` to nvim
+// instead of printing zonvie's own help text and exiting.
+if zonvieArgs.contains("--help") || zonvieArgs.contains("-h") {
     let help = """
         zonvie - A high-performance Neovim GUI
 
@@ -209,8 +223,11 @@ if args.contains("--help") || args.contains("-h") {
     exit(0)
 }
 
-// Handle --install: create default config.toml and exit
-if args.contains("--install") {
+// Handle --install: create default config.toml and exit.
+// Use zonvieArgs so `zonvie -- --install` forwards `--install` to nvim
+// (nvim has no such option but the user's intent is clear: don't run
+// zonvie's installer just because the token appears post `--`).
+if zonvieArgs.contains("--install") {
     let configURL = ZonvieConfig.configFilePath
     let configPath = configURL.path
     let fm = FileManager.default
@@ -253,6 +270,107 @@ if args.contains("--install") {
         }
     }
     exit(0)
+}
+
+// Validate flag exclusivity BEFORE the posix_spawnp fork branch below.
+// The fork makes the parent exit(0) once the child is spawned, which
+// hides any error printed afterwards from the terminal — both because
+// the parent has already returned success to the shell, and because
+// the child's stdio is redirected to /dev/null. By running the check
+// here, a CLI invocation like `zonvie --connect-nvim=... --ssh=...`
+// fails synchronously in the foreground process with a visible stderr
+// message instead of silently no-op'ing.
+//
+// `--connect-nvim` attaches to an already-running Neovim server;
+// `--ssh` / `--devcontainer` (and their config.toml equivalents
+// `[neovim].ssh` / `.wsl`) all SPAWN a wrapper-hosted nvim. The two
+// modes are mutually exclusive — silently letting connect mode
+// override (the previous behavior) would pick the user's wrapper
+// config out from under them. Refuse to start so the user can fix the
+// invocation explicitly.
+// Detect connect-mode usage AND capture its address in a single pass so
+// we can fail fast on bad invocations. Three classes of mistake we catch:
+//   1. Conflict with --ssh / --devcontainer (or their config.toml twins)
+//   2. Bare --connect-nvim / --remote-ui with no following value, which
+//      previously fell through silently to a regular nvim spawn
+//   3. --connect-nvim= or --remote-ui= with an empty value, which
+//      previously entered connect mode with addr=="" and surfaced as
+//      a confusing "Invalid core handle" alert from ZonvieCore.start.
+var connectModeEnabled = false
+var connectAddrCaptured: String? = nil
+do {
+    var i = 0
+    while i < zonvieArgs.count {
+        let arg = zonvieArgs[i]
+        if arg.hasPrefix("--connect-nvim=") {
+            connectModeEnabled = true
+            connectAddrCaptured = String(arg.dropFirst("--connect-nvim=".count))
+        } else if arg == "--connect-nvim" {
+            connectModeEnabled = true
+            if i + 1 < zonvieArgs.count {
+                connectAddrCaptured = zonvieArgs[i + 1]
+                i += 1
+            } else {
+                connectAddrCaptured = nil
+            }
+        } else if arg.hasPrefix("--remote-ui=") {
+            connectModeEnabled = true
+            connectAddrCaptured = String(arg.dropFirst("--remote-ui=".count))
+        } else if arg == "--remote-ui" {
+            connectModeEnabled = true
+            if i + 1 < zonvieArgs.count {
+                connectAddrCaptured = zonvieArgs[i + 1]
+                i += 1
+            } else {
+                connectAddrCaptured = nil
+            }
+        }
+        i += 1
+    }
+}
+if connectModeEnabled {
+    // (1) value missing or empty
+    if connectAddrCaptured == nil || connectAddrCaptured!.isEmpty {
+        let stderrMsg = "zonvie: --connect-nvim / --remote-ui requires a non-empty address (e.g. /tmp/nvim.sock or 127.0.0.1:6789).\n"
+        fputs(stderrMsg, stderr)
+        if launchedFromFinder {
+            _ = NSApplication.shared
+            let alert = NSAlert()
+            alert.messageText = "zonvie: invalid options"
+            alert.informativeText = "--connect-nvim / --remote-ui requires a non-empty address such as /tmp/nvim.sock or 127.0.0.1:6789."
+            alert.alertStyle = .critical
+            alert.addButton(withTitle: "Quit")
+            _ = alert.runModal()
+        }
+        Darwin.exit(1)
+    }
+    // (2) wrapper-mode conflict
+    var conflictParts: [String] = []
+    if sshModeEnabled || ZonvieConfig.shared.neovim.ssh {
+        conflictParts.append("--ssh / [neovim].ssh")
+    }
+    if devcontainerModeEnabled {
+        conflictParts.append("--devcontainer")
+    }
+    if !conflictParts.isEmpty {
+        let conflictDesc = conflictParts.joined(separator: " and ")
+        let stderrMsg = "zonvie: --connect-nvim is mutually exclusive with \(conflictDesc).\nRemove the conflicting option(s) and retry.\n"
+        fputs(stderrMsg, stderr)
+        // Finder launches have no parent terminal to read stderr — pop a
+        // modal dialog so the error is visible. Terminal launches see the
+        // stderr message above and don't need (and shouldn't get) an
+        // alert that would flash on screen and then disappear.
+        if launchedFromFinder {
+            _ = NSApplication.shared
+            let alert = NSAlert()
+            alert.messageText = "zonvie: invalid options"
+            alert.informativeText = "--connect-nvim is mutually exclusive with \(conflictDesc) (or the corresponding config.toml entry). Remove the conflicting option(s) and retry."
+            alert.alertStyle = .critical
+            alert.addButton(withTitle: "Quit")
+            _ = alert.runModal()
+        }
+        Darwin.exit(1)
+    }
 }
 
 if !noforkMode && !launchedFromFinder {
@@ -438,12 +556,13 @@ if !noforkMode && !launchedFromFinder {
 }
 // --nofork mode or no cache: keep current directory, stay attached to terminal
 
-// Configure logging before anything else
-// CLI --log takes precedence over config file
+// Configure logging before anything else.
+// CLI --log takes precedence over config file. Iterate zonvieArgs so
+// a post-`--` `--log` token (meant for nvim) is not consumed by zonvie.
 var cliLogPath: String? = nil
-for i in 0..<args.count {
-    if args[i] == "--log" && i + 1 < args.count {
-        cliLogPath = args[i + 1]
+for i in 0..<zonvieArgs.count {
+    if zonvieArgs[i] == "--log" && i + 1 < zonvieArgs.count {
+        cliLogPath = zonvieArgs[i + 1]
         break
     }
 }

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -3342,6 +3342,14 @@ final class ZonvieCore {
             self.pendingExternalVertices.removeValue(forKey: gridId)
             self.pendingExternalGridConfig.removeValue(forKey: gridId)
 
+            // Drop any queued window-creation request for this gridId.
+            // resetSessionState fires close callbacks for every external
+            // grid at session boundary; if a request was queued (window
+            // not yet created when the request landed in the queue),
+            // a later processPendingExternalWindows() would otherwise
+            // resurrect the stale gridId from the previous session.
+            self.pendingExternalWindowRequests.removeAll { $0.gridId == gridId }
+
             if let window = self.externalWindows.removeValue(forKey: gridId) {
                 // Save window position for restoration on tab switch back.
                 // Evict the entry with the lowest gridId to bound growth

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -1041,14 +1041,29 @@ final class ZonvieCore {
             }
             if arg.hasPrefix("--connect-nvim=") {
                 connectAddr = String(arg.dropFirst("--connect-nvim=".count))
-            } else if arg == "--connect-nvim" && argIdx + 1 < args.count {
-                connectAddr = args[argIdx + 1]
-                argIdx += 1
+            } else if arg == "--connect-nvim" {
+                // Defense-in-depth: main.swift already exits 1 for a bare
+                // --connect-nvim, but ZonvieCore.start can be invoked
+                // with arbitrary CommandLine.arguments. Set an empty
+                // address so the addr.isEmpty branch below returns -3
+                // instead of falling through to a regular nvim spawn.
+                if argIdx + 1 < args.count {
+                    connectAddr = args[argIdx + 1]
+                    argIdx += 1
+                } else {
+                    connectAddr = ""
+                }
             } else if arg.hasPrefix("--remote-ui=") {
                 connectAddr = String(arg.dropFirst("--remote-ui=".count))
-            } else if arg == "--remote-ui" && argIdx + 1 < args.count {
-                connectAddr = args[argIdx + 1]
-                argIdx += 1
+            } else if arg == "--remote-ui" {
+                // Mirror --connect-nvim: bare flag with no value yields
+                // an empty address that gets rejected synchronously.
+                if argIdx + 1 < args.count {
+                    connectAddr = args[argIdx + 1]
+                    argIdx += 1
+                } else {
+                    connectAddr = ""
+                }
             } else if arg.hasPrefix("--ssh=") {
                 let value = String(arg.dropFirst("--ssh=".count))
                 // Parse user@host:port format (port is after last colon, but only if it's numeric)
@@ -1103,8 +1118,11 @@ final class ZonvieCore {
 
         // === Connect mode (--connect-nvim / --remote-ui) ===
         // Attach to a running Neovim server at <addr>; skip spawn entirely.
-        // Mutually exclusive with SSH / devcontainer; if both are passed, the
-        // connect address wins and the user is warned.
+        // Mutually exclusive with SSH / devcontainer (and their config.toml
+        // twins). The combination is rejected up front in main.swift's
+        // pre-fork validation; this function double-checks and returns -3
+        // if a wrapper-mode flag still slipped through (matches Windows
+        // main.zig's reject behavior).
         if let addr = connectAddr {
             // main.swift filters this earlier, but treat empty addresses
             // as invalid here too: ZonvieCore.start can be invoked with
@@ -1117,8 +1135,17 @@ final class ZonvieCore {
                 ZonvieCore.appLog("[start] connect mode: empty listen_addr -> -3")
                 return -3
             }
+            // CLI contract: --connect-nvim is mutually exclusive with
+            // --ssh / --devcontainer (and their config.toml twins
+            // [neovim].ssh / .wsl). main.swift's pre-fork validation
+            // already exits 1 in that case before reaching here, and
+            // Windows main.zig does the same. Keep this defensive
+            // reject so ZonvieCore.start cannot accidentally pick
+            // connect over a wrapper config — silently dropping the
+            // user's --ssh would be a worse failure than -3.
             if sshHost != nil || devcontainerWorkspace != nil {
-                ZonvieCore.appLog("[start] WARN: --connect-nvim/--remote-ui overrides --ssh / --devcontainer")
+                ZonvieCore.appLog("[start] connect mode rejected: mutually exclusive with --ssh / --devcontainer / [neovim].ssh / [neovim].wsl -> -3")
+                return -3
             }
             ZonvieCore.appLog("[start] connect mode: attaching to listen_addr=\(addr)")
 

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -851,6 +851,28 @@ final class ZonvieCore {
                     rowsDelta: Int(rowsDelta),
                     totalRows: Int(totalRows), totalCols: Int(totalCols)
                 )
+            },
+            on_restart: { ctx, addrPtr, addrLen in
+                guard let ctx else { return }
+                let core = Unmanaged<ZonvieCore>.fromOpaque(ctx).takeUnretainedValue()
+                let addr: String
+                if let p = addrPtr, addrLen > 0 {
+                    addr = String(decoding: UnsafeBufferPointer(start: p, count: addrLen), as: UTF8.self)
+                } else {
+                    addr = ""
+                }
+                core.handleRestartEvent(listenAddr: addr)
+            },
+            on_connect: { ctx, addrPtr, addrLen in
+                guard let ctx else { return }
+                let core = Unmanaged<ZonvieCore>.fromOpaque(ctx).takeUnretainedValue()
+                let addr: String
+                if let p = addrPtr, addrLen > 0 {
+                    addr = String(decoding: UnsafeBufferPointer(start: p, count: addrLen), as: UTF8.self)
+                } else {
+                    addr = ""
+                }
+                core.handleConnectEvent(serverAddr: addr)
             }
         )
 
@@ -1002,10 +1024,25 @@ final class ZonvieCore {
         var devcontainerConfig: String? = nil
         var devcontainerRebuild: Bool = false
 
+        // Parse connect-mode arguments: --connect-nvim=<addr> or --remote-ui=<addr> (alias).
+        // When set, Zonvie skips spawning nvim and attaches to the running server
+        // at <addr> instead. Mutually exclusive with SSH / devcontainer modes.
+        var connectAddr: String? = nil
+
         var argIdx = 0
         while argIdx < args.count {
             let arg = args[argIdx]
-            if arg.hasPrefix("--ssh=") {
+            if arg.hasPrefix("--connect-nvim=") {
+                connectAddr = String(arg.dropFirst("--connect-nvim=".count))
+            } else if arg == "--connect-nvim" && argIdx + 1 < args.count {
+                connectAddr = args[argIdx + 1]
+                argIdx += 1
+            } else if arg.hasPrefix("--remote-ui=") {
+                connectAddr = String(arg.dropFirst("--remote-ui=".count))
+            } else if arg == "--remote-ui" && argIdx + 1 < args.count {
+                connectAddr = args[argIdx + 1]
+                argIdx += 1
+            } else if arg.hasPrefix("--ssh=") {
                 let value = String(arg.dropFirst("--ssh=".count))
                 // Parse user@host:port format (port is after last colon, but only if it's numeric)
                 if let lastColon = value.lastIndex(of: ":"),
@@ -1056,6 +1093,38 @@ final class ZonvieCore {
         }
 
         ZonvieCore.appLog("[start] SSH config: host=\(sshHost ?? "nil"), port=\(sshPort ?? -1), identity=\(sshIdentity ?? "nil")")
+
+        // === Connect mode (--connect-nvim / --remote-ui) ===
+        // Attach to a running Neovim server at <addr>; skip spawn entirely.
+        // Mutually exclusive with SSH / devcontainer; if both are passed, the
+        // connect address wins and the user is warned.
+        if let addr = connectAddr {
+            if sshHost != nil || devcontainerWorkspace != nil {
+                ZonvieCore.appLog("[start] WARN: --connect-nvim/--remote-ui overrides --ssh / --devcontainer")
+            }
+            ZonvieCore.appLog("[start] connect mode: attaching to listen_addr=\(addr)")
+
+            // Performance / IME / blur knobs identical to spawn path; the
+            // core only needs them set before the run-thread starts.
+            setBlurEnabled(true)
+            setInheritCwd(noforkMode)
+            let perfConfig = config.performance
+            zonvie_core_set_glyph_cache_size(
+                core,
+                UInt32(perfConfig.glyphCacheAsciiSize),
+                UInt32(perfConfig.glyphCacheNonAsciiSize)
+            )
+            zonvie_core_set_atlas_size(core, UInt32(perfConfig.atlasSize))
+            zonvie_core_set_option_as_meta(core, ZonvieConfig.shared.ime.optionAsMeta.rawValue)
+
+            let utf8 = Array(addr.utf8)
+            let result = utf8.withUnsafeBufferPointer { buf -> Int32 in
+                guard let base = buf.baseAddress else { return -1 }
+                return zonvie_core_start_connect(core, base, buf.count, rows, cols)
+            }
+            zonvie_core_set_log_enabled(core, ZonvieCore.appLogEnabled ? 1 : 0)
+            return result
+        }
 
         // Build final command path (quote if path contains spaces for Zig parser)
         var finalPath: String
@@ -2553,6 +2622,22 @@ final class ZonvieCore {
             guard let window = self?.terminalView?.window else { return }
             window.title = titleStr
         }
+    }
+
+    /// Receive the `restart` UI event from the core. Informational only —
+    /// the core handles the actual reconnect (TCP / Unix-socket connect to
+    /// listen_addr) transparently while the GUI continues running. The
+    /// matching `on_exit` is suppressed inside the core, so this is the
+    /// only signal a frontend gets that nvim swapped underneath.
+    fileprivate func handleRestartEvent(listenAddr: String) {
+        ZonvieCore.appLog("restart: reconnecting to listen_addr=\(listenAddr)")
+    }
+
+    /// Receive the `connect` UI event (`:connect <addr>`). Same flicker-free
+    /// reconnect as restart; the only difference is that the previous
+    /// server keeps running headless instead of dying.
+    fileprivate func handleConnectEvent(serverAddr: String) {
+        ZonvieCore.appLog("connect: hot-swap to server_addr=\(serverAddr)")
     }
 
 

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -1032,6 +1032,13 @@ final class ZonvieCore {
         var argIdx = 0
         while argIdx < args.count {
             let arg = args[argIdx]
+            // Stop parsing zonvie-side options at `--`; everything after the
+            // separator is forwarded verbatim to nvim. Without this guard,
+            // `zonvie -- --ssh=...` (where `--ssh=...` is meant for nvim)
+            // would erroneously trip zonvie's SSH/connect/devcontainer paths.
+            if arg == "--" {
+                break
+            }
             if arg.hasPrefix("--connect-nvim=") {
                 connectAddr = String(arg.dropFirst("--connect-nvim=".count))
             } else if arg == "--connect-nvim" && argIdx + 1 < args.count {
@@ -1099,6 +1106,17 @@ final class ZonvieCore {
         // Mutually exclusive with SSH / devcontainer; if both are passed, the
         // connect address wins and the user is warned.
         if let addr = connectAddr {
+            // main.swift filters this earlier, but treat empty addresses
+            // as invalid here too: ZonvieCore.start can be invoked with
+            // arbitrary CommandLine.arguments, and an empty Swift string
+            // makes Array("".utf8).withUnsafeBufferPointer hand back a
+            // nil baseAddress, which previously masked the real failure
+            // (invalid address) as a generic "Invalid core handle" (-1).
+            // Reject up front so the frontend reports -3 (invalid addr).
+            if addr.isEmpty {
+                ZonvieCore.appLog("[start] connect mode: empty listen_addr -> -3")
+                return -3
+            }
             if sshHost != nil || devcontainerWorkspace != nil {
                 ZonvieCore.appLog("[start] WARN: --connect-nvim/--remote-ui overrides --ssh / --devcontainer")
             }

--- a/src/core/c_api.zig
+++ b/src/core/c_api.zig
@@ -498,6 +498,17 @@ pub const Callbacks = extern struct {
         total_rows: u32,
         total_cols: u32,
     ) callconv(.c) void = null,
+
+    // Restart UI event observer (informational; core handles reconnect).
+    // Appended at the end of the struct to preserve ABI for older callers
+    // that pass a smaller callbacks_size to zonvie_core_create.
+    on_restart: ?*const fn (ctx: ?*anyopaque, listen_addr: [*]const u8, listen_addr_len: usize) callconv(.c) void = null,
+
+    // Connect UI event observer (informational; core handles reconnect).
+    // Appended after on_restart for the same ABI-compat reason. Old callers
+    // that don't fill this field get a null callback and lose the
+    // notification — the reconnect itself still happens transparently.
+    on_connect: ?*const fn (ctx: ?*anyopaque, server_addr: [*]const u8, server_addr_len: usize) callconv(.c) void = null,
 };
 
 
@@ -561,6 +572,8 @@ pub export fn zonvie_core_create(cb: ?*const Callbacks, callbacks_size: usize, c
 
         .on_exit = box.cb.on_exit,
         .on_set_title = box.cb.on_set_title,
+        .on_restart = box.cb.on_restart,
+        .on_connect = box.cb.on_connect,
 
         .on_external_window = box.cb.on_external_window,
         .on_external_window_close = box.cb.on_external_window_close,
@@ -660,6 +673,27 @@ pub export fn zonvie_core_start(p: ?*zonvie_core, nvim_path_c: ?[*:0]const u8, r
     const box = asBox(p.?);
     const nvim_path = if (nvim_path_c) |s| std.mem.span(s) else "nvim";
     box.core.start(nvim_path, rows, cols) catch return -2;
+    return 0;
+}
+
+/// Start in connect mode: attach to a running Neovim server at
+/// listen_addr instead of spawning a child. Address forms supported:
+///   - "host:port"        TCP
+///   - "/abs/path"        Unix domain socket
+/// Windows named pipes are not yet supported; on Windows the connect
+/// returns an error and the run loop exits without firing on_exit.
+pub export fn zonvie_core_start_connect(
+    p: ?*zonvie_core,
+    listen_addr: ?[*]const u8,
+    listen_addr_len: usize,
+    rows: u32,
+    cols: u32,
+) callconv(.c) i32 {
+    if (p == null) return -1;
+    const box = asBox(p.?);
+    const addr = if (listen_addr) |s| s[0..listen_addr_len] else return -3;
+    if (addr.len == 0) return -3;
+    box.core.startConnect(addr, rows, cols) catch return -2;
     return 0;
 }
 

--- a/src/core/c_api.zig
+++ b/src/core/c_api.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const core = @import("nvim_core.zig");
 pub const config = @import("config.zig");
 const shader_compiler = @import("shader_compiler.zig");
+const rpc_transport = @import("rpc_transport.zig");
 
 // Re-exports for test access
 pub const nvim_core = core;
@@ -678,10 +679,14 @@ pub export fn zonvie_core_start(p: ?*zonvie_core, nvim_path_c: ?[*:0]const u8, r
 
 /// Start in connect mode: attach to a running Neovim server at
 /// listen_addr instead of spawning a child. Address forms supported:
-///   - "host:port"        TCP
-///   - "/abs/path"        Unix domain socket
-/// Windows named pipes are not yet supported; on Windows the connect
-/// returns an error and the run loop exits without firing on_exit.
+///   POSIX (macOS, Linux): "host:port" (TCP) or "/abs/path" (Unix socket)
+///   Windows:              "\\.\pipe\..." (named pipe); TCP and Unix
+///                         sockets are not yet supported.
+///
+/// Address validity (parse errors and platform-unsupported forms) is
+/// checked synchronously and returned as -3 before the run-loop thread
+/// is spawned, so callers can react immediately instead of waiting for
+/// an async on_exit.
 pub export fn zonvie_core_start_connect(
     p: ?*zonvie_core,
     listen_addr: ?[*]const u8,
@@ -691,9 +696,20 @@ pub export fn zonvie_core_start_connect(
 ) callconv(.c) i32 {
     if (p == null) return -1;
     const box = asBox(p.?);
-    const addr = if (listen_addr) |s| s[0..listen_addr_len] else return -3;
-    if (addr.len == 0) return -3;
+    const addr = if (listen_addr) |s| s[0..listen_addr_len] else {
+        box.core.log.write("[c_api] start_connect: listen_addr=null -> -3\n", .{});
+        return -3;
+    };
+    box.core.log.write("[c_api] start_connect: enter addr_len={d} addr=\"{s}\"\n", .{ addr.len, addr });
+    if (addr.len == 0) {
+        box.core.log.write("[c_api] start_connect: empty addr -> -3\n", .{});
+        return -3;
+    }
+    const supported = rpc_transport.isAddrSupported(addr);
+    box.core.log.write("[c_api] start_connect: isAddrSupported(\"{s}\") = {}\n", .{ addr, supported });
+    if (!supported) return -3;
     box.core.startConnect(addr, rows, cols) catch return -2;
+    box.core.log.write("[c_api] start_connect: thread spawned, returning 0\n", .{});
     return 0;
 }
 

--- a/src/core/flush.zig
+++ b/src/core/flush.zig
@@ -4161,6 +4161,14 @@ pub const FlushCtx = struct {
     pub fn onDefaultColors(ctx: *FlushCtx, fg: u32, bg: u32) !void {
         ctx.core.emitDefaultColors(fg, bg);
     }
+
+    pub fn onRestart(ctx: *FlushCtx, listen_addr: []const u8) !void {
+        try ctx.core.handleRestartEvent(listen_addr);
+    }
+
+    pub fn onConnect(ctx: *FlushCtx, server_addr: []const u8) !void {
+        try ctx.core.handleConnectEvent(server_addr);
+    }
 };
 
 pub fn notifyExternalWindowChanges(self: *Core) bool {

--- a/src/core/grid.zig
+++ b/src/core/grid.zig
@@ -1025,6 +1025,99 @@ pub const Grid = struct {
         self.cell_overflow.deinit(self.alloc);
     }
 
+    /// Reset all channel-bound state for a new RPC session (`:restart`,
+    /// `:connect`, hot-swap connect, etc.).
+    ///
+    /// The new server uses a fresh grid_id space and never sends
+    /// `grid_destroy` / `cmdline_hide` / `popupmenu_hide` / `tabline_hide`
+    /// / `msg_clear` for the previous session's UI overlays. Without an
+    /// explicit teardown, any leftover entry in `sub_grids` / `win_pos` /
+    /// `win_layer` is rendered as a stale composited float by
+    /// flush.zig:rebuildMain and reported as a visible grid by
+    /// nvim_core.zig:getVisibleGridsLocked (hit-testing). The same logic
+    /// applies to ext UI state that survives across the channel close.
+    ///
+    /// Preserves intentionally:
+    ///   - global grid (id=1) cells / dimensions: the new session's
+    ///     `grid_resize 1` + `grid_line` overwrite progressively, and the
+    ///     frontend's last committed frame keeps the screen stable
+    ///     between sessions (no flush runs in the gap).
+    ///   - `hl` highlight table: caller's responsibility (lives outside
+    ///     this struct); the new session redefines hl_ids via hl_attr_define.
+    ///   - mode info / cursor shape: redefined by the new session's
+    ///     `mode_info_set` + `mode_change`.
+    ///   - dirty bitmap state: `markAllDirty()` is invoked so the first
+    ///     post-attach flush of the new session unconditionally rebuilds.
+    ///
+    /// Capacity-retaining clears are used so the next session does not
+    /// pay reallocation cost for typical workloads.
+    pub fn resetForNewSession(self: *Grid) void {
+        // Composited / multigrid layout: stale entries here would be
+        // emitted as floats by flush.zig:rebuildMain (iterating win_pos)
+        // and counted as visible by getVisibleGridsLocked.
+        var sg_it = self.sub_grids.iterator();
+        while (sg_it.next()) |e| {
+            e.value_ptr.deinit(self.alloc);
+        }
+        self.sub_grids.clearRetainingCapacity();
+        self.win_pos.clearRetainingCapacity();
+        self.grid_win_ids.clearRetainingCapacity();
+        self.win_layer.clearRetainingCapacity();
+        self.viewport.clearRetainingCapacity();
+        self.viewport_margins.clearRetainingCapacity();
+        self.grid_metrics.clearRetainingCapacity();
+        self.cell_overflow.clearRetainingCapacity();
+        self.layer_order_counter = 0;
+        self.composited_win_closed = false;
+
+        // Cursor: a stale `cursor_grid` pointing at a now-deleted sub_grid
+        // would briefly drive cursor rendering at a stale offset before
+        // the new session's first grid_cursor_goto arrives.
+        self.cursor_grid = 1;
+        self.cursor_row = 0;
+        self.cursor_col = 0;
+        self.cursor_valid = false;
+        self.prev_cursor_row = null;
+        self.prev_cursor_grid = null;
+
+        // ext_cmdline: the new server has no notion of these levels.
+        // Mark dirty so the next flush re-emits hide based on absence
+        // of any visible level.
+        var cm_it = self.cmdline_states.iterator();
+        while (cm_it.next()) |e| {
+            e.value_ptr.deinit(self.alloc);
+        }
+        self.cmdline_states.clearRetainingCapacity();
+        self.cmdline_block.clear(self.alloc);
+        self.cmdline_dirty = true;
+
+        // ext_popupmenu / ext_tabline / ext_messages.
+        self.popupmenu.clear(self.alloc);
+        self.tabline_state.clear(self.alloc);
+        self.message_state.clear(self.alloc);
+        self.msg_history_state.clear(self.alloc);
+
+        // Scroll bookkeeping: a pending op refers to the old session's
+        // grid_id and would apply to an unrelated grid in the new
+        // session if grid_ids overlap.
+        self.pending_scroll = null;
+        self.scroll_fast_path_blocked = false;
+        self.scrolled_grid_count = 0;
+        self.scroll_touched_count = 0;
+
+        // Bump revs so any rev-equality short-circuit (e.g. last_sent_*
+        // tracking on the Core side) cannot match the new session's
+        // first frame against the old session's last frame.
+        self.content_rev +%= 1;
+        self.cursor_rev +%= 1;
+
+        // Force the first flush of the new session to redraw grid 1.
+        // grid_resize will markAllDirty too, but this is the no-op-resize
+        // case (same dimensions) where redraw_handler doesn't reach
+        // resizeGrid.
+        self.dirty_all = true;
+    }
+
     // ── Cell overflow helpers ────────────────────────────────────────
 
     /// Store extra codepoints for a multi-codepoint cell.

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -823,6 +823,16 @@ pub const Core = struct {
     /// layout dimensions) is intentionally NOT touched — those carry over
     /// to the new server unchanged so the user sees no flicker.
     ///
+    /// EXCEPTION: external windows (multigrid windows mapped to OS-level
+    /// windows by the frontend) ARE channel-bound. The new server uses a
+    /// fresh grid_id space, so old grid_ids in known_external_grids /
+    /// grid.external_grids would never receive grid_resize from the new
+    /// server and never appear in the closed-detection diff at
+    /// flush.notifyExternalWindowChanges. Without explicit teardown, the
+    /// stale OS windows remain visible holding dead grid state. Fire
+    /// on_external_window_close for each known grid_id and clear both
+    /// maps before the next session.
+    ///
     /// MUST be called only from the RPC thread, after the previous
     /// session's writer thread has been joined and pipes/sockets closed.
     pub fn resetSessionState(self: *Core) void {
@@ -867,6 +877,25 @@ pub const Core = struct {
         self.writer_failed = false;
         self.write_queue.clearRetainingCapacity();
         self.write_queue_mu.unlock();
+
+        // Tear down channel-bound external windows. See doc comment above
+        // for the rationale (new server's grid_id space is fresh, so the
+        // diff at notifyExternalWindowChanges never fires on stale ids).
+        // Fire close callbacks first so the frontend can dismiss its OS
+        // windows; then clear both maps so the new session starts with an
+        // empty external-grid registry.
+        if (self.known_external_grids.count() > 0) {
+            const closed_count = self.known_external_grids.count();
+            if (self.cb.on_external_window_close) |cb| {
+                var it = self.known_external_grids.keyIterator();
+                while (it.next()) |grid_id_ptr| {
+                    cb(self.ctx, grid_id_ptr.*);
+                }
+            }
+            self.known_external_grids.clearRetainingCapacity();
+            self.log.write("resetSessionState: closed {d} external windows from previous session\n", .{closed_count});
+        }
+        self.grid.external_grids.clearRetainingCapacity();
 
         self.log.write("resetSessionState: cleared session-scoped state\n", .{});
     }
@@ -928,6 +957,13 @@ pub const Core = struct {
         // The same alias guard lives in cleanupSession() (rpc_session.zig)
         // — keep both sides in sync.
         if (self.stdin_file) |f| {
+            // For POSIX .socket transport (connect mode, where stdin/
+            // stdout alias the same fd) close() alone does not wake
+            // the reader/writer thread blocked on the fd. Issue
+            // shutdown(SHUT_RDWR) first so those threads return EOF /
+            // EPIPE and can be join()ed below; otherwise stop() would
+            // hang waiting on self.thread / writer thread join.
+            f.shutdownIfSocket(self.transport_kind == .socket);
             f.close();
             self.stdin_file = null;
             if (self.transport_kind == .socket) {

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -20,6 +20,15 @@ const vertexgen = @import("vertexgen.zig");
 /// on_external_window so the frontend can update window position.
 pub const KnownExtGridInfo = struct { win: i64, start_row: i32, start_col: i32, rows: u32, cols: u32 };
 
+/// Backing transport for the current RPC session.
+pub const TransportKind = enum {
+    /// Spawned nvim child process; stdin/stdout/stderr are 3 separate pipes.
+    pipes,
+    /// Connected to a running nvim server over TCP or unix socket.
+    /// stdin_file and stdout_file alias the same fd; stderr_file is null.
+    socket,
+};
+
 pub const Callbacks = struct {
     on_vertices_partial: ?*const fn (
         ctx: ?*anyopaque,
@@ -59,6 +68,18 @@ pub const Callbacks = struct {
 
     /// Called when Neovim sets the window title (set_title UI event).
     on_set_title: ?*const fn (ctx: ?*anyopaque, title: [*]const u8, title_len: usize) callconv(.c) void = null,
+
+    /// Called when Neovim sends the `restart` UI event (`:restart` command).
+    /// listen_addr is the new server address that the core will attach to.
+    /// Informational only — the core handles the actual reconnect; the
+    /// frontend must NOT tear down its window or treat this as `on_exit`.
+    on_restart: ?*const fn (ctx: ?*anyopaque, listen_addr: [*]const u8, listen_addr_len: usize) callconv(.c) void = null,
+
+    /// Called when Neovim sends the `connect` UI event (`:connect <addr>`).
+    /// server_addr is the server the UI is being hot-swapped to. Same
+    /// reconnect machinery as `on_restart`; the only difference is that
+    /// the previous server keeps running headless (it is not dying).
+    on_connect: ?*const fn (ctx: ?*anyopaque, server_addr: [*]const u8, server_addr_len: usize) callconv(.c) void = null,
 
     /// Called when a grid should be displayed in an external window.
     on_external_window: ?*const fn (ctx: ?*anyopaque, grid_id: i64, win: i64, rows: u32, cols: u32, start_row: i32, start_col: i32) callconv(.c) void = null,
@@ -439,6 +460,26 @@ pub const Core = struct {
     stderr_file: ?std.fs.File = null,
     stderr_thread: ?std.Thread = null,
 
+    /// Transport mode of the current session.
+    /// .pipes: spawned child + 3 pipes (stdin/stdout/stderr separate handles).
+    /// .socket: connected to a running nvim via TCP/Unix socket. In this mode
+    /// stdin_file and stdout_file alias the same fd; close() must run only
+    /// once and stderr_file is null.
+    transport_kind: TransportKind = .pipes,
+
+    /// Set by handleRestartEvent to the new server's listen address (owned).
+    /// Observed by the RPC run loop after the current session terminates;
+    /// when non-null, the loop reconnects to this address instead of firing
+    /// on_exit. Cleared once the next session is established.
+    restart_pending_addr: ?[]u8 = null,
+
+    /// Set by handleConnectEvent. When true, the run loop's cleanup must
+    /// NOT wait on or kill the spawned child — `:connect` is a hot-swap
+    /// where the old nvim stays alive headless and would otherwise make
+    /// child.wait() block forever. The handle is dropped (orphaned).
+    /// Consumed (reset to false) by the run loop before the next iteration.
+    connect_keeps_child_alive: bool = false,
+
     drawable_w_px: u32 = 1,
     drawable_h_px: u32 = 1,
     cell_w_px: u32 = 1,
@@ -715,6 +756,81 @@ pub const Core = struct {
         self.started = true;
     }
 
+    /// Start in connect mode: attach to a Neovim server already listening
+    /// at `listen_addr` (TCP `host:port` or Unix socket path) instead of
+    /// spawning a child. Used by both the future "connect to running
+    /// nvim" CLI flag and as the initial entry that the runLoop already
+    /// supports via the `:restart` machinery.
+    ///
+    /// nvim_path_owned is left empty so the connect-failure fall-through
+    /// inside runLoop does NOT silently spawn a local nvim — that would
+    /// surprise a caller who explicitly opted into connect mode.
+    pub fn startConnect(self: *Core, listen_addr: []const u8, rows: u32, cols: u32) !void {
+        self.init_rows = rows;
+        self.init_cols = cols;
+        self.nvim_path_owned = self.alloc.dupe(u8, "") catch null;
+        // Pre-populate restart_pending_addr so the run loop's first
+        // iteration takes the connect path. Same machinery as `:restart`.
+        self.restart_pending_addr = try self.alloc.dupe(u8, listen_addr);
+        self.thread = try std.Thread.spawn(.{}, runLoop, .{self});
+        self.started = true;
+    }
+
+    /// Reset session-scoped state between RPC sessions (called by the run
+    /// loop when transitioning to the next session for `:restart`). Clears
+    /// transient flags and in-flight RPC msgids so the new session starts
+    /// from a clean slate. Persistent state (grid, hl, atlas, ext UI,
+    /// layout dimensions) is intentionally NOT touched — those carry over
+    /// to the new server unchanged so the user sees no flicker.
+    ///
+    /// MUST be called only from the RPC thread, after the previous
+    /// session's writer thread has been joined and pipes/sockets closed.
+    pub fn resetSessionState(self: *Core) void {
+        // UI attachment must be re-issued after reconnect.
+        self.ui_attached.store(false, .seq_cst);
+
+        // Channel-bound state.
+        self.clipboard_setup_done = false;
+
+        // In-flight RPC IDs from the dead channel — drop tracking so any
+        // stale response from the new server (very unlikely; new msgid
+        // counter starts fresh on the nvim side) does not match.
+        self.get_api_info_msgid = null;
+        self.quit_request_msgid.store(0, .release);
+        self.glow_request_msgid.store(0, .release);
+
+        // Re-arm the glow startup probe so it queries vim.g.zonvie_glow on
+        // the new server (the user's init.lua may set it again, identically
+        // or differently).
+        self.glow_startup_retries = 30;
+
+        // Pending focus state from before the reconnect should not leak —
+        // the new server has its own initial focus state.
+        self.pending_focus.store(0, .seq_cst);
+
+        // SSH auth flags only apply to spawn-mode SSH sessions; reset so a
+        // future spawn-mode session (re-spawn fallback) starts unauthenticated.
+        self.ssh_auth_pending.store(false, .seq_cst);
+        self.ssh_auth_done.store(false, .seq_cst);
+
+        // Transport handles are cleaned up by the caller (closed and nulled);
+        // here we only flip the kind tag for clarity until the next session
+        // re-assigns it.
+        self.transport_kind = .pipes;
+
+        // Re-arm the writer queue: the previous session's cleanup set
+        // write_queue_closed=true so the writer thread would drain and exit.
+        // Clearing it now allows startWriterThread() to succeed for the
+        // next session.
+        self.write_queue_mu.lock();
+        self.write_queue_closed = false;
+        self.writer_failed = false;
+        self.write_queue.clearRetainingCapacity();
+        self.write_queue_mu.unlock();
+
+        self.log.write("resetSessionState: cleared session-scoped state\n", .{});
+    }
+
     /// Signal the RPC thread that the actual layout is known and nvim_ui_attach
     /// can be sent with the correct dimensions. Must be called from the UI
     /// thread after the renderer is initialized and actual rows/cols are computed.
@@ -810,6 +926,13 @@ pub const Core = struct {
         if (self.nvim_path_owned) |p| {
             self.alloc.free(p);
             self.nvim_path_owned = null;
+        }
+
+        // Free any pending restart address (queued but never consumed because
+        // stop() raced ahead of the run loop's restart handling).
+        if (self.restart_pending_addr) |a| {
+            self.alloc.free(a);
+            self.restart_pending_addr = null;
         }
 
         // Free shaping buffers (Phase B)
@@ -1993,6 +2116,74 @@ pub const Core = struct {
         if (self.cb.on_default_colors_set) |f| {
             f(self.ctx, fg, bg);
         }
+    }
+
+    pub fn emitOnRestart(self: *Core, listen_addr: []const u8) void {
+        if (self.cb.on_restart) |f| {
+            f(self.ctx, listen_addr.ptr, listen_addr.len);
+        }
+    }
+
+    pub fn emitOnConnect(self: *Core, server_addr: []const u8) void {
+        if (self.cb.on_connect) |f| {
+            f(self.ctx, server_addr.ptr, server_addr.len);
+        }
+    }
+
+    /// Handle the `restart` UI event from Neovim. Records the new server's
+    /// listen address and signals the current session to shut down. The RPC
+    /// run loop observes restart_pending_addr and reconnects on the next
+    /// session iteration instead of firing on_exit.
+    ///
+    /// Called from the redraw thread (grid_mu held).
+    pub fn handleRestartEvent(self: *Core, listen_addr: []const u8) !void {
+        // Drop any previously queued restart (only the latest matters).
+        if (self.restart_pending_addr) |old| {
+            self.alloc.free(old);
+            self.restart_pending_addr = null;
+        }
+
+        const owned = self.alloc.dupe(u8, listen_addr) catch |e| {
+            self.log.write("handleRestartEvent: dupe failed: {any}\n", .{e});
+            return e;
+        };
+        self.restart_pending_addr = owned;
+
+        self.log.write("handleRestartEvent: listen_addr={s}\n", .{listen_addr});
+
+        // Notify frontend (informational; frontend MUST NOT close window).
+        self.emitOnRestart(listen_addr);
+
+        // The RPC run loop will observe restart_pending_addr after the
+        // current session terminates (nvim closes the channel). We do NOT
+        // proactively close stdin here because nvim is in the middle of
+        // sending its final batch (the `restart` event itself is part of
+        // that batch). Letting the read side EOF naturally is cleaner.
+    }
+
+    /// Handle the `connect` UI event from Neovim (`:connect <addr>`). The
+    /// reconnect machinery is identical to `restart` — we record the new
+    /// server's address in restart_pending_addr and let the run loop
+    /// observe it after the channel closes — but the frontend gets a
+    /// distinct `on_connect` callback so it can distinguish a hot-swap
+    /// (`:connect`, old server stays alive headless) from a server
+    /// replacement (`:restart`, old server dies).
+    pub fn handleConnectEvent(self: *Core, server_addr: []const u8) !void {
+        if (self.restart_pending_addr) |old| {
+            self.alloc.free(old);
+            self.restart_pending_addr = null;
+        }
+
+        const owned = self.alloc.dupe(u8, server_addr) catch |e| {
+            self.log.write("handleConnectEvent: dupe failed: {any}\n", .{e});
+            return e;
+        };
+        self.restart_pending_addr = owned;
+        self.connect_keeps_child_alive = true;
+
+        self.log.write("handleConnectEvent: server_addr={s}\n", .{server_addr});
+
+        self.emitOnConnect(server_addr);
     }
 
     /// Dedicated writer thread: drains write_queue and writes to stdin pipe.

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -464,6 +464,13 @@ pub const Core = struct {
     stdout_file: ?Stream = null,
     stderr_file: ?Stream = null,
     stderr_thread: ?std.Thread = null,
+    /// Heap-allocated state shared with the stderr pump thread.
+    /// Lifetime: created at session spawn, freed by the pump thread's
+    /// run() defer block on exit. This back-pointer in Core is just a
+    /// handle for cleanupSession to call detachFromCore() before the
+    /// pump might outlive Core (`:connect` orphan path). Always null
+    /// it after detach / join — the pump destroys the struct itself.
+    stderr_pump: ?*rpc_session.StderrPump = null,
 
     /// Transport mode of the current session.
     /// .pipes: spawned child + 3 pipes (stdin/stdout/stderr separate handles).
@@ -1012,6 +1019,17 @@ pub const Core = struct {
         if (self.thread) |t| t.join();
         self.thread = null;
 
+        // Defensive: if a stderr pump is still pointing at Core (e.g., a
+        // failure path bypassed cleanupSession), detach it now so its
+        // run() loop stops dereferencing Core before we free Core's
+        // storage below, then release Core's ref so the struct can be
+        // freed when the pump thread releases its own. Normal flows
+        // have cleanupSession already null both fields by this point.
+        if (self.stderr_pump) |p| {
+            p.detachFromCore();
+            p.release();
+            self.stderr_pump = null;
+        }
         if (self.stderr_thread) |t2| t2.join();
         self.stderr_thread = null;
 
@@ -3154,10 +3172,6 @@ pub const Core = struct {
 
 
     // --- Forwarding stubs for rpc_session.zig ---
-
-    pub fn pumpStderr(self: *Core, f: Stream) void {
-        rpc_session.pumpStderr(self, f);
-    }
 
     pub fn containsPasswordPrompt(data: []const u8) bool {
         return rpc_session.containsPasswordPrompt(data);

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -878,12 +878,16 @@ pub const Core = struct {
         self.write_queue.clearRetainingCapacity();
         self.write_queue_mu.unlock();
 
-        // Tear down channel-bound external windows. See doc comment above
-        // for the rationale (new server's grid_id space is fresh, so the
-        // diff at notifyExternalWindowChanges never fires on stale ids).
+        // Tear down channel-bound external-window state. See doc comment
+        // above for the rationale (new server's grid_id space is fresh,
+        // so any stale grid_id left in these maps can later be matched
+        // against an unrelated win_pos / grid_resize from the new server
+        // and silently re-promote a normal window to "external", or feed
+        // a stale target size into the next win_external_pos diff).
+        //
         // Fire close callbacks first so the frontend can dismiss its OS
-        // windows; then clear both maps so the new session starts with an
-        // empty external-grid registry.
+        // windows; then clear every channel-bound map so the new session
+        // starts with an empty external-grid registry.
         if (self.known_external_grids.count() > 0) {
             const closed_count = self.known_external_grids.count();
             if (self.cb.on_external_window_close) |cb| {
@@ -896,6 +900,23 @@ pub const Core = struct {
             self.log.write("resetSessionState: closed {d} external windows from previous session\n", .{closed_count});
         }
         self.grid.external_grids.clearRetainingCapacity();
+        // ext_windows_grids: grid_id -> win_id mapping. Without clearing,
+        // a fresh win_pos for the same grid_id on the new server hits
+        // the redraw_handler.zig stale-detection path that re-promotes
+        // it to external (redraw_handler.zig:~1171).
+        self.grid.ext_windows_grids.clearRetainingCapacity();
+        // external_grid_target_sizes: dimensions used to match resize
+        // events to known external grids (redraw_handler.zig:~960).
+        // Stale entries would feed the wrong size into the new session.
+        self.grid.external_grid_target_sizes.clearRetainingCapacity();
+        // pending_ext_window_grids: grids waiting for their first
+        // grid_resize before the frontend window is created.
+        self.grid.pending_ext_window_grids.clearRetainingCapacity();
+        // pending_grid_resizes / pending_win_ops: queued ops referring
+        // to old-session grid_ids; carrying them across would apply to
+        // unrelated grids in the new session.
+        self.grid.pending_grid_resizes.clearRetainingCapacity();
+        self.grid.pending_win_ops.clearRetainingCapacity();
 
         self.log.write("resetSessionState: cleared session-scoped state\n", .{});
     }

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -824,11 +824,48 @@ pub const Core = struct {
     }
 
     /// Reset session-scoped state between RPC sessions (called by the run
-    /// loop when transitioning to the next session for `:restart`). Clears
-    /// transient flags and in-flight RPC msgids so the new session starts
-    /// from a clean slate. Persistent state (grid, hl, atlas, ext UI,
-    /// layout dimensions) is intentionally NOT touched — those carry over
-    /// to the new server unchanged so the user sees no flicker.
+    /// loop when transitioning to the next session for `:restart` /
+    /// `:connect`). Clears transient flags, in-flight RPC msgids, and
+    /// every piece of state tied to the previous server's grid_id space
+    /// or UI overlays so the new session starts from a clean slate.
+    ///
+    /// Channel-bound state (cleared here):
+    ///   - external windows + their grid registry (existing, see below)
+    ///   - composited grid layout: sub_grids / win_pos / grid_win_ids /
+    ///     win_layer / viewport(_margins) / cell_overflow / grid_metrics.
+    ///     The new server never sends grid_destroy for grid_ids it does
+    ///     not know about, so leftover entries would be rendered as
+    ///     stale floats (flush.zig:rebuildMain) and reported as visible
+    ///     by getVisibleGridsLocked (hit-testing).
+    ///   - ext UI state: cmdline_states / cmdline_block / popupmenu /
+    ///     tabline_state / message_state / msg_history_state. The new
+    ///     server does not send hide events for overlays it never
+    ///     created.
+    ///   - cursor state: cursor_grid may point at a now-deleted sub_grid.
+    ///   - Core-side flush bookkeeping: last_sent_*_rev, msg throttle
+    ///     state, last_cmd snapshot, popupmenu Lua-mirror handles,
+    ///     pre_cmdline cursor snapshot, prev_subgrid_snapshots.
+    ///
+    /// Frontend overlay teardown:
+    ///   - external_grids cleanup below already fires on_external_window_close
+    ///     for cmdline / popupmenu / message / msg_history overlays
+    ///     (those use external grid_ids -100..-103).
+    ///   - tabline lives outside that path, so on_tabline_hide is fired
+    ///     explicitly. on_popupmenu_hide / on_msg_clear are also fired
+    ///     defensively in case the frontend tracks overlay state outside
+    ///     the external-grid path.
+    ///
+    /// Preserved intentionally:
+    ///   - global grid (id=1) cells/dimensions: the new server overwrites
+    ///     them via grid_resize + grid_line right after attach. The
+    ///     frontend's last committed frame keeps the screen visually
+    ///     stable in the gap (no flush runs between sessions).
+    ///   - hl table: hl_ids are redefined by hl_attr_define on attach.
+    ///   - atlas / glyph caches / shape cache: keyed by content + style
+    ///     + font_generation; valid as long as font is unchanged.
+    ///   - mode info / cursor shape / cursor_visible: replaced by the
+    ///     new session's mode_info_set + mode_change.
+    ///   - layout dimensions (last_layout_rows/cols, init_rows/cols).
     ///
     /// EXCEPTION: external windows (multigrid windows mapped to OS-level
     /// windows by the frontend) ARE channel-bound. The new server uses a
@@ -885,6 +922,26 @@ pub const Core = struct {
         self.write_queue.clearRetainingCapacity();
         self.write_queue_mu.unlock();
 
+        // === Grid-protected critical section ===
+        //
+        // Everything below mutates state that the frontend reads under
+        // grid_mu via the public C API (`zonvie_core_get_visible_grids`,
+        // viewport / cursor lookups, message tick, etc.). Without this
+        // lock, a frontend reader holding grid_mu could race with us
+        // clear/deinit'ing AutoHashMap nodes or sub_grid cell buffers.
+        //
+        // Locking contract (matches handleRedraw at rpc_session.zig:849):
+        // frontend callbacks (on_external_window_close, on_tabline_hide,
+        // on_popupmenu_hide, on_msg_clear) execute while grid_mu is held.
+        // Callbacks MUST NOT call zonvie_core_get_* or any other API that
+        // re-acquires grid_mu, otherwise this thread will deadlock against
+        // its own lock.
+        //
+        // The `defer unlock` covers every early return path here (none
+        // exist today, but future edits stay safe).
+        self.grid_mu.lock();
+        defer self.grid_mu.unlock();
+
         // Tear down channel-bound external-window state. See doc comment
         // above for the rationale (new server's grid_id space is fresh,
         // so any stale grid_id left in these maps can later be matched
@@ -924,6 +981,65 @@ pub const Core = struct {
         // unrelated grids in the new session.
         self.grid.pending_grid_resizes.clearRetainingCapacity();
         self.grid.pending_win_ops.clearRetainingCapacity();
+
+        // Composited / multigrid layout, ext UI overlays, cursor state.
+        // See doc comment on this function for the full rationale.
+        self.grid.resetForNewSession();
+
+        // Frontend overlay teardown for paths not covered by the external
+        // window cleanup above. The cmdline / popupmenu / message external
+        // grids are torn down via on_external_window_close (fired by the
+        // known_external_grids loop above), but:
+        //   - tabline is rendered without an external grid; without an
+        //     explicit hide the frontend keeps the old tabs on screen
+        //     until the new session sends tabline_update.
+        //   - on_popupmenu_hide / on_msg_clear are fired defensively in
+        //     case the frontend tracks overlay state outside the
+        //     external-grid path (e.g. an in-window popup overlay).
+        if (self.cb.on_tabline_hide) |cb| cb(self.ctx);
+        if (self.cb.on_popupmenu_hide) |cb| cb(self.ctx);
+        if (self.cb.on_msg_clear) |cb| cb(self.ctx);
+
+        // Core-side flush bookkeeping. Without resetting these, the next
+        // flush could short-circuit on rev equality or use stale
+        // window-handle references from the previous channel.
+        // These fields are consulted from the flush path which already
+        // runs under grid_mu (see handleRedraw); resetting them inside
+        // this critical section keeps the flush invariants consistent.
+        self.last_sent_content_rev = 0;
+        self.last_sent_cursor_rev = 0;
+        self.last_ext_cursor_grid = 1;
+        self.last_ext_cursor_rev = 0;
+        self.pre_cmdline_cursor_grid = 1;
+        self.pre_cmdline_cursor_row = 0;
+        self.pre_cmdline_cursor_col = 0;
+        self.popupmenu_win_id = null;
+        self.popupmenu_buf_id = null;
+
+        // ext_messages timing / scroll state was tied to the old session's
+        // msg_show events; carrying it across would auto-hide the new
+        // session's first message at the old deadline.
+        self.msg_show_pending_since = null;
+        self.msg_show_auto_hide_at = null;
+        self.msg_history_auto_hide_at = null;
+        self.msg_scroll_offset = 0;
+        self.msg_total_lines = 0;
+        self.msg_cached_max_width = 0;
+        self.msg_scroll_pending = false;
+        self.msg_scroll_last_send = 0;
+        self.msg_cache_valid = false;
+        // MsgCachedLine has only fixed-size buffers (no heap-owned strings).
+        self.msg_line_cache.clearRetainingCapacity();
+
+        // Last command tracking for the split-view label was a snapshot
+        // of the old session's :commands.
+        self.last_cmd_len = 0;
+        self.last_cmd_firstc = 0;
+        self.last_cmd_start_time = null;
+
+        // Subgrid layout snapshot for scroll fast path: stale entries
+        // would reference grid_ids the new session has not (yet) created.
+        self.prev_subgrid_snapshot_count = 0;
 
         self.log.write("resetSessionState: cleared session-scoped state\n", .{});
     }

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -12,8 +12,13 @@ const Logger = @import("log.zig").Logger;
 const config = @import("config.zig");
 const flush = @import("flush.zig");
 const rpc_session = @import("rpc_session.zig");
+const rpc_transport = @import("rpc_transport.zig");
 const shelf_packer = @import("shelf_packer.zig");
 const vertexgen = @import("vertexgen.zig");
+
+/// Re-exported here so callers in this file can spell `Stream` without
+/// reaching into `rpc_transport`.
+pub const Stream = rpc_transport.Stream;
 
 /// Position/size snapshot for a known external grid. Used to detect
 /// changes in anchor position (e.g. popupmenu re-show) and re-fire
@@ -455,9 +460,9 @@ pub const Core = struct {
     thread: ?std.Thread = null,
 
     child_handle: ?std.process.Child.Id = null,
-    stdin_file: ?std.fs.File = null,
-    stdout_file: ?std.fs.File = null,
-    stderr_file: ?std.fs.File = null,
+    stdin_file: ?Stream = null,
+    stdout_file: ?Stream = null,
+    stderr_file: ?Stream = null,
     stderr_thread: ?std.Thread = null,
 
     /// Transport mode of the current session.
@@ -1422,7 +1427,7 @@ pub const Core = struct {
     /// Signals ssh_auth_done after writing.
     pub fn sendStdinData(self: *Core, data: []const u8) void {
         if (self.stdin_file) |f| {
-            _ = f.write(data) catch |e| {
+            f.writeAll(data) catch |e| {
                 self.log.write("sendStdinData write err: {any}\n", .{e});
                 return;
             };
@@ -2187,8 +2192,8 @@ pub const Core = struct {
     }
 
     /// Dedicated writer thread: drains write_queue and writes to stdin pipe.
-    /// Receives the file handle by value to avoid racing with stop().
-    fn writerThreadFn(self: *Core, file: std.fs.File) void {
+    /// Receives the stream by value to avoid racing with stop().
+    fn writerThreadFn(self: *Core, file: Stream) void {
         var drain: std.ArrayListUnmanaged(u8) = .{};
         defer drain.deinit(self.alloc);
 
@@ -3030,7 +3035,7 @@ pub const Core = struct {
 
     // --- Forwarding stubs for rpc_session.zig ---
 
-    pub fn pumpStderr(self: *Core, f: std.fs.File) void {
+    pub fn pumpStderr(self: *Core, f: Stream) void {
         rpc_session.pumpStderr(self, f);
     }
 

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -472,11 +472,46 @@ pub const Core = struct {
     /// once and stderr_file is null.
     transport_kind: TransportKind = .pipes,
 
-    /// Set by handleRestartEvent to the new server's listen address (owned).
-    /// Observed by the RPC run loop after the current session terminates;
-    /// when non-null, the loop reconnects to this address instead of firing
-    /// on_exit. Cleared once the next session is established.
+    /// Owning pointer to the Windows named-pipe wrapper for the current
+    /// session, when transport_kind == .socket and the platform is Windows.
+    /// stdin_file / stdout_file's `Stream.close()` calls
+    /// `WindowsOverlappedPipe.closeHandles()` which only fires
+    /// `CancelIoEx` to abort pending overlapped I/O — neither the pipe
+    /// HANDLE nor the event HANDLEs are closed there, because closing
+    /// a HANDLE another thread is still using as the file argument to
+    /// `GetOverlappedResult` (or as the wait HANDLE for an overlapped
+    /// completion event) is undefined behavior per MSDN. The pipe
+    /// HANDLE, the event HANDLEs, and the heap-allocated wrapper are
+    /// all released exactly once via `session_pipe.destroy()` from
+    /// cleanupSession, AFTER the writer / stderr threads have been
+    /// joined. Without this separation, stop()/cleanupSession would
+    /// close those HANDLEs and `alloc.destroy(self)` while the writer
+    /// thread was still mid-writeAll(), corrupting kernel state and
+    /// heap memory. Null on POSIX and on spawn-mode sessions.
+    session_pipe: ?*rpc_transport.WindowsOverlappedPipe = null,
+
+    /// Set by handleRestartEvent / handleConnectEvent to the next session's
+    /// listen address (owned). Observed by the RPC run loop after the
+    /// current session terminates; when non-null, the loop reconnects to
+    /// this address instead of firing on_exit. Cleared once the next
+    /// session is established.
     restart_pending_addr: ?[]u8 = null,
+
+    /// Distinguishes how `restart_pending_addr` was queued:
+    ///   - false (default): set by handleRestartEvent. The old nvim died
+    ///     and a new instance came up at this address; if connecting back
+    ///     fails, falling through to spawn the original argv is the
+    ///     correct recovery (the user lost their session anyway).
+    ///   - true: set by handleConnectEvent. `:connect` is a hot-swap that
+    ///     orphans the old nvim (still alive headless on its own listen
+    ///     socket); if connecting to the NEW server fails, spawning a
+    ///     fresh local nvim would orphan the user's editing session in
+    ///     the old nvim while opening a wholly different blank session.
+    ///     Exit the run loop instead so the frontend can surface the
+    ///     failure.
+    /// Consumed (reset to false) by the run loop alongside
+    /// restart_pending_addr.
+    restart_pending_is_connect_hotswap: bool = false,
 
     /// Set by handleConnectEvent. When true, the run loop's cleanup must
     /// NOT wait on or kill the spawned child — `:connect` is a hot-swap
@@ -876,13 +911,34 @@ pub const Core = struct {
             self.write_queue_mu.unlock();
         }
 
-        // Close stdin to unblock writer thread's writeAll() if it's blocked on pipe I/O
+        // Unblock writer thread's writeAll() if blocked on transport I/O.
+        // Transport-specific semantics of Stream.close():
+        //   - POSIX (.file): closes the fd outright. For socket transport
+        //     (connect mode) stdin_file and stdout_file alias the same fd;
+        //     a second close would close an unrelated fd that the kernel
+        //     may have already recycled, so we null the alias to skip
+        //     cleanupSession's stdout close.
+        //   - Windows named pipe (.win_pipe): calls closeHandles() which
+        //     only fires CancelIoEx — the pipe HANDLE itself stays alive
+        //     until session_pipe.destroy() runs in cleanupSession (after
+        //     all threads holding a Stream value have been joined). We
+        //     still null the stdout alias to keep the cleanupSession path
+        //     symmetric: closeHandles is idempotent under its swap()
+        //     guard, but skipping the duplicate call is clearer.
+        // The same alias guard lives in cleanupSession() (rpc_session.zig)
+        // — keep both sides in sync.
         if (self.stdin_file) |f| {
             f.close();
             self.stdin_file = null;
+            if (self.transport_kind == .socket) {
+                self.stdout_file = null;
+            }
         }
 
-        // Join writer thread (exits due to closed flag or I/O error from stdin close)
+        // Join writer thread. It exits via:
+        //   - clean shutdown: write_queue_closed observed with empty queue
+        //   - I/O error: POSIX broken-pipe from the stdin close above, or
+        //     OperationAborted from CancelIoEx on the Windows pipe HANDLE
         if (wt) |t| t.join();
 
         if (self.child_handle) |_| {
@@ -934,11 +990,13 @@ pub const Core = struct {
         }
 
         // Free any pending restart address (queued but never consumed because
-        // stop() raced ahead of the run loop's restart handling).
+        // stop() raced ahead of the run loop's restart handling). Reset the
+        // companion hot-swap flag too — the run loop reads them as a pair.
         if (self.restart_pending_addr) |a| {
             self.alloc.free(a);
             self.restart_pending_addr = null;
         }
+        self.restart_pending_is_connect_hotswap = false;
 
         // Free shaping buffers (Phase B)
         self.shaping_bufs.deinit(self.alloc);
@@ -2153,6 +2211,10 @@ pub const Core = struct {
             return e;
         };
         self.restart_pending_addr = owned;
+        // Explicit reset in case a prior :connect queued (then aborted) left
+        // the hot-swap flag set; :restart is NOT a hot-swap (the old nvim
+        // dies), so spawn fallback on connect failure is the desired recovery.
+        self.restart_pending_is_connect_hotswap = false;
 
         self.log.write("handleRestartEvent: listen_addr={s}\n", .{listen_addr});
 
@@ -2184,6 +2246,7 @@ pub const Core = struct {
             return e;
         };
         self.restart_pending_addr = owned;
+        self.restart_pending_is_connect_hotswap = true;
         self.connect_keeps_child_alive = true;
 
         self.log.write("handleConnectEvent: server_addr={s}\n", .{server_addr});

--- a/src/core/redraw_handler.zig
+++ b/src/core/redraw_handler.zig
@@ -65,6 +65,8 @@ pub const RedrawEvent = enum {
     msg_history_show,
     msg_history_clear,
     set_title,
+    restart,
+    connect,
     flush,
 };
 
@@ -808,6 +810,8 @@ pub fn handleRedrawStream(
     linespace_fn: *const fn (ctx: @TypeOf(linespace_ctx), px: i32) anyerror!void,
     set_title_fn: ?*const fn (ctx: @TypeOf(opt_ctx), title: []const u8) anyerror!void,
     default_colors_fn: ?*const fn (ctx: @TypeOf(opt_ctx), fg: u32, bg: u32) anyerror!void,
+    restart_fn: ?*const fn (ctx: @TypeOf(opt_ctx), listen_addr: []const u8) anyerror!void,
+    connect_fn: ?*const fn (ctx: @TypeOf(opt_ctx), server_addr: []const u8) anyerror!void,
 ) !void {
     var ei: u32 = 0;
     while (ei < n_events) : (ei += 1) {
@@ -880,6 +884,8 @@ pub fn handleRedrawStream(
             linespace_fn,
             set_title_fn,
             default_colors_fn,
+            restart_fn,
+            connect_fn,
         ) catch |re| {
             log.write("redraw dispatch err: {any}\n", .{re});
             const remaining = n_events - ei - 1;
@@ -891,7 +897,7 @@ pub fn handleRedrawStream(
 
 /// Supported redraw events:
 /// grid_resize, grid_line, grid_clear, grid_cursor_goto, hl_attr_define,
-/// default_colors_set, option_set, set_title, flush
+/// default_colors_set, option_set, set_title, restart, connect, flush
 pub fn handleRedraw(
     grid: *Grid,
     hl: *Highlights,
@@ -906,6 +912,8 @@ pub fn handleRedraw(
     linespace_fn: *const fn (ctx: @TypeOf(linespace_ctx), px: i32) anyerror!void,
     set_title_fn: ?*const fn (ctx: @TypeOf(opt_ctx), title: []const u8) anyerror!void,
     default_colors_fn: ?*const fn (ctx: @TypeOf(opt_ctx), fg: u32, bg: u32) anyerror!void,
+    restart_fn: ?*const fn (ctx: @TypeOf(opt_ctx), listen_addr: []const u8) anyerror!void,
+    connect_fn: ?*const fn (ctx: @TypeOf(opt_ctx), server_addr: []const u8) anyerror!void,
 ) !void {
 
     for (params) |ev| {
@@ -2375,6 +2383,45 @@ pub fn handleRedraw(
                     const title = t[0].str;
                     if (log.cb != null) log.write("set_title: {s}\n", .{title});
                     try fn_ptr(opt_ctx, title);
+                }
+            }
+
+        }, .restart => {
+            // restart: [listen_addr]
+            // Nvim invoked :restart and started a new server. The current
+            // channel is about to close; the UI should attach to the new
+            // server at listen_addr after the close is observed.
+            if (restart_fn) |fn_ptr| {
+                for (tuples) |tv| {
+                    if (tv != .arr) continue;
+                    const t = tv.arr;
+                    if (t.len < 1 or t[0] != .str) continue;
+
+                    const listen_addr = t[0].str;
+                    if (log.cb != null) log.write("restart: listen_addr={s}\n", .{listen_addr});
+                    try fn_ptr(opt_ctx, listen_addr);
+                }
+            }
+
+        }, .connect => {
+            // connect: [server_addr]
+            // Nvim invoked :connect and detached the current UI. Unlike
+            // restart, the old server keeps running headless; the UI
+            // should immediately attach to the new server at server_addr.
+            // The core's reconnect machinery is identical for both events
+            // (only the old-server fate differs, and the UI sees the same
+            // channel-close handshake), but the dispatcher routes through
+            // a distinct callback so the frontend can tell them apart for
+            // logging / UI-hint purposes.
+            if (connect_fn) |fn_ptr| {
+                for (tuples) |tv| {
+                    if (tv != .arr) continue;
+                    const t = tv.arr;
+                    if (t.len < 1 or t[0] != .str) continue;
+
+                    const server_addr = t[0].str;
+                    if (log.cb != null) log.write("connect: server_addr={s}\n", .{server_addr});
+                    try fn_ptr(opt_ctx, server_addr);
                 }
             }
 

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -2,6 +2,7 @@
 // Extracted from nvim_core.zig. Free functions take *Core as first parameter.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const c_api = @import("c_api.zig");
 const grid_mod = @import("grid.zig");
 const highlight = @import("highlight.zig");
@@ -1742,6 +1743,18 @@ fn cleanupSession(
     if (have_child) {
         if (orphan_child) {
             self.log.write("orphaning headless nvim (pid={any}) for :connect hot-swap\n", .{child.id});
+            // On Windows std.process.Child.Id is a HANDLE and there is
+            // also a thread_handle for the main thread. Normally
+            // child.wait() closes both, but the orphan path skips
+            // wait() (the headless nvim never exits, so wait would
+            // block forever). Close them explicitly so repeated
+            // :connect hot-swaps don't leak HANDLEs. POSIX has no
+            // resources to free here — id is a pid_t, thread_handle
+            // is zero-sized void — so the block is Windows-only.
+            if (builtin.os.tag == .windows) {
+                std.os.windows.CloseHandle(child.id);
+                std.os.windows.CloseHandle(child.thread_handle);
+            }
             self.child_handle = null;
         } else {
             // Kill conditions:

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -17,7 +17,7 @@ const Callbacks = nvim_core.Callbacks;
 const rpc_transport = @import("rpc_transport.zig");
 
 pub const PipeReader = struct {
-    file: std.fs.File,
+    file: rpc_transport.Stream,
     buf: [8192]u8 = undefined,
     start: usize = 0,
     end: usize = 0,
@@ -78,7 +78,7 @@ pub const PipeReader = struct {
 /// The buffer grows on demand up to `max_capacity` when a single frame
 /// exceeds the current capacity with no consumable tail to compact.
 pub const FrameReader = struct {
-    file: std.fs.File,
+    file: rpc_transport.Stream,
     alloc: std.mem.Allocator,
     buf: []u8,
     pos: usize = 0,
@@ -86,7 +86,7 @@ pub const FrameReader = struct {
 
     pub const initial_capacity: usize = 64 * 1024;
 
-    pub fn init(alloc: std.mem.Allocator, file: std.fs.File) !FrameReader {
+    pub fn init(alloc: std.mem.Allocator, file: rpc_transport.Stream) !FrameReader {
         const buf = try alloc.alloc(u8, initial_capacity);
         return .{ .file = file, .alloc = alloc, .buf = buf };
     }
@@ -238,7 +238,7 @@ pub const CwdOwner = struct {
     }
 };
 
-pub fn pumpStderr(self: *Core, f: std.fs.File) void {
+pub fn pumpStderr(self: *Core, f: rpc_transport.Stream) void {
     var buf: [4096]u8 = undefined;
     while (!self.stop_flag.load(.seq_cst)) {
         const n = f.read(&buf) catch break;
@@ -1303,14 +1303,14 @@ pub fn runLoop(self: *Core) void {
         defer cwd_owner.close();
 
         if (use_connect) {
-            const conn_opt: ?rpc_transport.Connection = rpc_transport.connectListenAddr(self.alloc, session_addr.?) catch |e| blk: {
+            const conn_opt: ?rpc_transport.Stream = rpc_transport.connectListenAddr(self.alloc, session_addr.?) catch |e| blk: {
                 self.log.write("connect to {s} failed: {any}; falling back to re-spawn\n", .{ session_addr.?, e });
                 break :blk null;
             };
             if (conn_opt) |conn| {
                 self.transport_kind = .socket;
-                self.stdin_file = conn.file;
-                self.stdout_file = conn.file; // alias of the same fd
+                self.stdin_file = conn;
+                self.stdout_file = conn; // alias of the same fd / pipe wrapper
                 self.stderr_file = null;
                 self.log.write("connect: established socket session to {s}\n", .{session_addr.?});
             } else if (nvim_path.len == 0) {
@@ -1370,9 +1370,9 @@ pub fn runLoop(self: *Core) void {
 
             self.transport_kind = .pipes;
             self.child_handle = child.id;
-            self.stdin_file = child.stdin;
-            self.stdout_file = child.stdout;
-            self.stderr_file = child.stderr;
+            self.stdin_file = if (child.stdin) |f| rpc_transport.Stream.fromFile(f) else null;
+            self.stdout_file = if (child.stdout) |f| rpc_transport.Stream.fromFile(f) else null;
+            self.stderr_file = if (child.stderr) |f| rpc_transport.Stream.fromFile(f) else null;
 
             // OWNERSHIP TRANSFER: keep handles in Core; prevent Child from closing them.
             child.stdin = null;
@@ -1565,6 +1565,19 @@ pub fn runLoop(self: *Core) void {
             }
             if (t == 2) {
                 handleRpcNotification(self, arena, top);
+                // If the notification queued a restart/connect, exit the
+                // inner loop now so cleanup can run and the next session
+                // iteration can pick up restart_pending_addr. For local
+                // spawn this isn't strictly necessary (the channel
+                // closes naturally when nvim exits), but for SSH /
+                // devcontainer / WSL the new nvim inherits stdio from
+                // the old one and the SSH/wrapper stdio never EOFs —
+                // so we'd be stuck in this loop forever waiting for a
+                // close that never comes.
+                if (self.restart_pending_addr != null) {
+                    self.log.write("inner loop: restart/connect queued; breaking to trigger cleanup\n", .{});
+                    break :outer;
+                }
                 continue;
             }
         }
@@ -1608,7 +1621,14 @@ pub fn runLoop(self: *Core) void {
                 self.log.write("orphaning headless nvim (pid={any}) for :connect hot-swap\n", .{child.id});
                 self.child_handle = null;
             } else {
-                if (self.stop_flag.load(.seq_cst)) {
+                // User stop OR restart/connect queued via the inner-loop
+                // early break: kill the child to ensure it terminates
+                // promptly. For local spawn the child is usually already
+                // dead (nvim self-exits on :restart); kill is then a
+                // no-op. For SSH / devcontainer / WSL the wrapper
+                // process is still alive holding stdio open, and would
+                // make child.wait() block indefinitely without this kill.
+                if (self.stop_flag.load(.seq_cst) or self.restart_pending_addr != null) {
                     _ = child.kill() catch {};
                 }
                 session_term = child.wait() catch |e| blk: {

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -1472,7 +1472,7 @@ pub fn runLoop(self: *Core) void {
 
                 if (self.stop_flag.load(.seq_cst)) {
                     self.log.write("SSH mode: stopped by user\n", .{});
-                    _ = cleanupSession(self, &child, have_child, false);
+                    _ = cleanupSession(self, &child, have_child, false, false);
                     break :session;
                 }
             }
@@ -1497,7 +1497,7 @@ pub fn runLoop(self: *Core) void {
         }
 
         if (self.stop_flag.load(.seq_cst)) {
-            _ = cleanupSession(self, &child, have_child, false);
+            _ = cleanupSession(self, &child, have_child, false, false);
             break :session;
         }
 
@@ -1521,7 +1521,7 @@ pub fn runLoop(self: *Core) void {
 
         self.requestUiAttach(self.ui_attach_rows, self.ui_attach_cols) catch |e| {
             self.log.write("ui_attach send failed: {any}\n", .{e});
-            _ = cleanupSession(self, &child, have_child, true);
+            _ = cleanupSession(self, &child, have_child, true, false);
             break :session;
         };
         ui_attached = true;
@@ -1550,19 +1550,27 @@ pub fn runLoop(self: *Core) void {
 
         if (self.stdout_file == null) {
             self.log.write("read transport is null\n", .{});
-            _ = cleanupSession(self, &child, have_child, true);
+            _ = cleanupSession(self, &child, have_child, true, false);
             break :session;
         }
 
         var fr = FrameReader.init(self.alloc, self.stdout_file.?) catch |e| {
             self.log.write("FrameReader init failed: {any}\n", .{e});
-            _ = cleanupSession(self, &child, have_child, true);
+            _ = cleanupSession(self, &child, have_child, true, false);
             break :session;
         };
         defer fr.deinit();
 
         var arena_state = std.heap.ArenaAllocator.init(self.alloc);
         defer arena_state.deinit();
+
+        // Tracks how the inner loop exited:
+        //   false = natural EOF / read error / stop_flag (local restart
+        //           takes this path — nvim is exiting on its own)
+        //   true  = early break because a remote-mode restart/connect
+        //           is queued and the wrapper stdio will never EOF
+        // Passed to cleanupSession as `kill_on_restart_pending`.
+        var remote_restart_break: bool = false;
 
         // Inner reader loop — same for both transports. Earlier iterations
         // experimented with a streaming fast path here; microbenchmarks
@@ -1613,29 +1621,47 @@ pub fn runLoop(self: *Core) void {
             }
             if (t == 2) {
                 handleRpcNotification(self, arena, top);
-                // If the notification queued a restart/connect, exit the
-                // inner loop now so cleanup can run and the next session
-                // iteration can pick up restart_pending_addr. For local
-                // spawn this isn't strictly necessary (the channel
-                // closes naturally when nvim exits), but for SSH /
-                // devcontainer / WSL the new nvim inherits stdio from
-                // the old one and the SSH/wrapper stdio never EOFs —
-                // so we'd be stuck in this loop forever waiting for a
-                // close that never comes.
+                // If the notification queued a restart/connect, decide
+                // whether to break the inner loop NOW or wait for the
+                // natural channel close.
+                //
+                // Remote modes (SSH / WSL / devcontainer / cmd / shell):
+                // the new nvim inherits stdio from the wrapper which
+                // never EOFs, so we MUST break here — otherwise we'd be
+                // stuck reading forever. cleanupSession will then kill
+                // the wrapper to unblock wait().
+                //
+                // Local spawn: nvim is in the middle of its own clean
+                // shutdown (channel close + process exit). Breaking
+                // here would force cleanupSession to kill nvim mid-
+                // shutdown, racing with shada/viminfo flush, swap file
+                // deletion, etc. Instead, fall through and let the
+                // inner loop see the natural EOF (decode err path
+                // above), which breaks out cleanly. The kill in
+                // cleanupSession is then a true no-op on the already-
+                // exited child.
                 if (self.restart_pending_addr != null) {
-                    self.log.write("inner loop: restart/connect queued; breaking to trigger cleanup\n", .{});
-                    break :outer;
+                    if (is_remote_for_restart) {
+                        self.log.write("inner loop: restart/connect queued (remote); breaking immediately\n", .{});
+                        remote_restart_break = true;
+                        break :outer;
+                    }
+                    self.log.write("inner loop: restart/connect queued (local); waiting for natural EOF\n", .{});
                 }
                 continue;
             }
         }
 
         // === Session cleanup ===
-        // Natural inner-loop exit: kill conditions inside cleanupSession
-        // already cover stop_flag and restart_pending_addr, so no need to
-        // force-kill here. Propagate the term so on_exit can compute the
-        // right exit code from how nvim ended this session.
-        if (cleanupSession(self, &child, have_child, false)) |t| last_term = t;
+        // Natural inner-loop exit. cleanupSession's kill conditions cover
+        // stop_flag (user stop) automatically, so we don't force-kill
+        // here. `kill_on_restart_pending = remote_restart_break` lets
+        // remote-mode restarts kill the wrapper (whose stdio never EOFs)
+        // while local-mode restarts skip the kill so nvim can finish
+        // its own clean shutdown — channel close (EOF) is just one of
+        // the last steps in nvim's exit, not the end. Propagate the
+        // term so on_exit can compute the right exit code.
+        if (cleanupSession(self, &child, have_child, false, remote_restart_break)) |t| last_term = t;
 
         // === Decide next iteration ===
         if (self.stop_flag.load(.seq_cst)) {
@@ -1685,6 +1711,19 @@ pub fn runLoop(self: *Core) void {
     }
 }
 
+/// POSIX background reaper for `:connect` orphans. Without this, the
+/// orphaned headless nvim becomes a zombie when it eventually exits
+/// (e.g., `:connect!` from another UI, system shutdown), holding a
+/// kernel process-table entry until our process exits. The thread
+/// blocks in waitpid() until the orphan terminates, then naturally
+/// returns and self-cleans-up. Receives the Child by value so the
+/// owning runLoop frame can drop its local `child` without affecting
+/// the reaper.
+fn reapOrphanThread(orphan: std.process.Child) void {
+    var c = orphan;
+    _ = c.wait() catch {};
+}
+
 /// Tear down the current RPC session: stop the writer thread, close the
 /// transport (with socket-alias handling), reap the child (if any), and
 /// join the stderr pump. Safe to call from any session-exit path — both
@@ -1698,6 +1737,18 @@ pub fn runLoop(self: *Core) void {
 /// so wait() does not block (notably SSH / devcontainer / WSL where the
 /// wrapper holds stdio open until killed).
 ///
+/// `kill_on_restart_pending`: when true, kill the child if a restart /
+/// connect is queued. True for the remote-mode inner-loop early-break
+/// path (SSH / WSL / devcontainer / cmd / shell), where the wrapper
+/// holds stdio open and child.wait() would block forever without an
+/// explicit kill. False for the local-spawn natural-EOF path, where
+/// nvim closed its channel while in the middle of its own clean
+/// shutdown — child.wait() will reap shortly on its own. Killing in
+/// the local case truncates nvim's shutdown work (shada / viminfo
+/// flush, swap file deletion, etc.) and violates the Neovim restart
+/// UI event contract: the UI must wait for channel close + natural
+/// process exit, not force-terminate the old server.
+///
 /// Returns the child's exit term, or null if not available (no child,
 /// orphaned for a `:connect` hot-swap, or wait() failed). The caller
 /// decides whether to propagate the term to `last_term` for on_exit's
@@ -1707,6 +1758,7 @@ fn cleanupSession(
     child: *std.process.Child,
     have_child: bool,
     force_kill_child: bool,
+    kill_on_restart_pending: bool,
 ) ?std.process.Child.Term {
     // Stop the writer thread before closing the transport so its
     // in-flight writeAll() does not observe a torn-down handle.
@@ -1746,28 +1798,52 @@ fn cleanupSession(
             // On Windows std.process.Child.Id is a HANDLE and there is
             // also a thread_handle for the main thread. Normally
             // child.wait() closes both, but the orphan path skips
-            // wait() (the headless nvim never exits, so wait would
-            // block forever). Close them explicitly so repeated
-            // :connect hot-swaps don't leak HANDLEs. POSIX has no
-            // resources to free here — id is a pid_t, thread_handle
-            // is zero-sized void — so the block is Windows-only.
+            // wait() (the headless nvim never exits in the foreground
+            // case, so wait would block). Close them explicitly so
+            // repeated :connect hot-swaps don't leak HANDLEs. The
+            // process keeps running because HANDLEs are merely kernel-
+            // object references, not the process itself.
+            //
+            // On POSIX the orphan is reaped by a detached background
+            // thread. id is a pid_t (just an integer, no kernel HANDLE
+            // to close), but if we never waitpid() the orphan, it
+            // becomes a zombie when it eventually exits. The thread
+            // blocks in child.wait() and reaps the zombie when the
+            // orphan terminates. child.stdin/stdout/stderr were nulled
+            // on spawn (lines 1426-1428) so wait()'s cleanupStreams is
+            // a no-op — no double-close races with our own pipe
+            // teardown above.
             if (builtin.os.tag == .windows) {
                 std.os.windows.CloseHandle(child.id);
                 std.os.windows.CloseHandle(child.thread_handle);
+            } else {
+                if (std.Thread.spawn(.{}, reapOrphanThread, .{child.*})) |t| {
+                    t.detach();
+                } else |e| {
+                    self.log.write("orphan reaper spawn failed: {any}; pid {any} may zombie on exit\n", .{ e, child.id });
+                }
             }
             self.child_handle = null;
         } else {
             // Kill conditions:
-            //   - User stop OR restart/connect queued via inner-loop early
-            //     break: terminate promptly. For local spawn the child is
-            //     usually already dead (nvim self-exits on :restart); kill
-            //     is then a no-op. For SSH / devcontainer / WSL the wrapper
-            //     process is still alive holding stdio open, and would make
-            //     child.wait() block indefinitely without this kill.
+            //   - User stop (stop_flag): terminate promptly so we don't
+            //     block on wait().
             //   - force_kill_child: early-exit failure paths haven't set
             //     stop_flag, but still need the child reaped without
             //     blocking on wait().
-            if (force_kill_child or self.stop_flag.load(.seq_cst) or self.restart_pending_addr != null) {
+            //   - restart/connect pending AND kill_on_restart_pending:
+            //     remote modes (SSH / WSL / devcontainer / cmd / shell)
+            //     where the wrapper holds stdio open after nvim exits.
+            //     Without an explicit kill, wait() blocks forever on
+            //     the wrapper. The local-spawn natural-EOF path passes
+            //     kill_on_restart_pending=false so we let nvim finish
+            //     its shutdown (shada / viminfo / swap file cleanup)
+            //     and reap via wait() — EOF is channel close, not
+            //     process exit, so racing a kill against the still-in-
+            //     progress teardown would truncate nvim's work.
+            if (force_kill_child or self.stop_flag.load(.seq_cst) or
+                (kill_on_restart_pending and self.restart_pending_addr != null))
+            {
                 _ = child.kill() catch {};
             }
             session_term = child.wait() catch |e| blk: {

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -1806,11 +1806,14 @@ pub fn runLoop(self: *Core) void {
         // its own clean shutdown — channel close (EOF) is just one of
         // the last steps in nvim's exit, not the end. Propagate the
         // term so on_exit can compute the right exit code.
+        self.log.write("session loop: invoking cleanupSession (remote_restart_break={any})\n", .{remote_restart_break});
         if (cleanupSession(self, &child, have_child, false, remote_restart_break)) |t| last_term = t;
+        self.log.write("session loop: cleanupSession returned\n", .{});
 
         // === Decide next iteration ===
         if (self.stop_flag.load(.seq_cst)) {
             // App-side stop() observed; do not fire on_exit, do not loop.
+            self.log.write("session loop: stop_flag set after cleanup; returning\n", .{});
             return;
         }
 
@@ -1821,13 +1824,17 @@ pub fn runLoop(self: *Core) void {
             // Consume the connect-keeps-alive flag now that the orphan
             // (if any) has been dropped — the next session must not
             // inherit it.
+            self.log.write("session loop: restart_pending; entering resetSessionState\n", .{});
             self.connect_keeps_child_alive = false;
             self.resetSessionState();
+            self.log.write("session loop: resetSessionState returned\n", .{});
             if (self.stop_flag.load(.seq_cst)) return;
+            self.log.write("session loop: continuing to next iteration\n", .{});
             continue :session;
         }
 
         // Natural exit: nvim closed the channel without queueing a restart.
+        self.log.write("session loop: no restart pending; breaking out\n", .{});
         break :session;
     }
 
@@ -1912,6 +1919,13 @@ fn cleanupSession(
     force_kill_child: bool,
     kill_on_restart_pending: bool,
 ) ?std.process.Child.Term {
+    self.log.write("cleanupSession: enter (have_child={any} force_kill={any} kill_on_restart_pending={any} restart_pending={any} connect_keeps_child_alive={any})\n", .{
+        have_child,
+        force_kill_child,
+        kill_on_restart_pending,
+        self.restart_pending_addr != null,
+        self.connect_keeps_child_alive,
+    });
     // Stop the writer thread before closing the transport so its
     // in-flight writeAll() does not observe a torn-down handle.
     var wt: ?std.Thread = null;
@@ -1923,6 +1937,7 @@ fn cleanupSession(
         self.write_queue_cond.signal();
         self.write_queue_mu.unlock();
     }
+    self.log.write("cleanupSession: writer queue closed (wt_present={any})\n", .{wt != null});
     // `:connect` hot-swap: the old nvim is still alive headless on
     // its own listen socket and would block child.wait() forever
     // (the process never exits). Don't kill, don't wait — just drop
@@ -1939,6 +1954,7 @@ fn cleanupSession(
         // wt.join() below would hang. The reader does not run here
         // (we are on the runLoop thread, post inner-loop exit), so
         // it is naturally not affected.
+        self.log.write("cleanupSession: closing stdin (transport={any})\n", .{self.transport_kind});
         f.shutdownIfSocket(self.transport_kind == .socket);
         f.close();
         self.stdin_file = null;
@@ -1948,8 +1964,13 @@ fn cleanupSession(
         if (self.transport_kind == .socket) {
             self.stdout_file = null;
         }
+        self.log.write("cleanupSession: stdin closed\n", .{});
     }
-    if (wt) |t| t.join();
+    if (wt) |t| {
+        self.log.write("cleanupSession: joining writer thread\n", .{});
+        t.join();
+        self.log.write("cleanupSession: writer thread joined\n", .{});
+    }
 
     var session_term: ?std.process.Child.Term = null;
     if (have_child) {
@@ -2001,11 +2022,13 @@ fn cleanupSession(
             //     and reap via wait() — EOF is channel close, not
             //     process exit, so racing a kill against the still-in-
             //     progress teardown would truncate nvim's work.
-            if (force_kill_child or self.stop_flag.load(.seq_cst) or
-                (kill_on_restart_pending and self.restart_pending_addr != null))
-            {
+            const want_kill = force_kill_child or self.stop_flag.load(.seq_cst) or
+                (kill_on_restart_pending and self.restart_pending_addr != null);
+            if (want_kill) {
+                self.log.write("cleanupSession: killing child (pid={any})\n", .{child.id});
                 _ = child.kill() catch {};
             }
+            self.log.write("cleanupSession: waiting for child (pid={any} want_kill={any})\n", .{ child.id, want_kill });
             session_term = child.wait() catch |e| blk: {
                 self.log.write("wait err: {any}\n", .{e});
                 break :blk null;
@@ -2021,40 +2044,55 @@ fn cleanupSession(
     // blocked read syscall hasn't yet observed EOF and the fd number is
     // recycled by the next open() in our process. Just null the alias.
     if (self.stdout_file) |f| {
+        self.log.write("cleanupSession: closing stdout\n", .{});
         f.close();
         self.stdout_file = null;
+        self.log.write("cleanupSession: stdout closed\n", .{});
     }
     self.stderr_file = null;
 
     // Reap the stderr pump.
-    //   - Normal path: child died, its stderr writer closed, our pump
-    //     read returned 0, the pump thread is exiting (or already
-    //     exited). join() completes promptly.
+    //   - Final-shutdown path (no restart pending, no orphan): child
+    //     died, its stderr writer closed, our pump read returned 0,
+    //     the pump thread is exiting (or already exited). join()
+    //     completes promptly.
     //   - Orphan path (`:connect` hot-swap): the old nvim is still
     //     running and holds the stderr writer open, so the pump is
     //     stuck in a blocking read that close() on the read end does
     //     NOT wake on POSIX. Joining would hang the run loop and
-    //     prevent attaching to the new server. Detach instead — the
-    //     pump exits naturally when the orphan eventually closes its
-    //     stderr (process exit, :connect! from another UI, etc.) and
-    //     the defer in StderrPump.run releases the fd and frees the
-    //     pump struct.
+    //     prevent attaching to the new server. Detach instead.
+    //   - Restart-pending path (`:restart`): even though the old
+    //     nvim has exited, the headless successor it spawned to host
+    //     the new session may have inherited a stray write reference
+    //     to our stderr pipe across the libuv fork (uv_spawn with
+    //     UV_IGNORE on stderr replaces the child's fd 2 with
+    //     /dev/null but does NOT close OTHER inherited fds without
+    //     CLOEXEC; if old nvim's libuv held a dup of fd 2 elsewhere,
+    //     the successor keeps our pipe writer open). The successor
+    //     outlives the run-loop here by design — we are about to
+    //     attach to it — so its inherited fd never closes during
+    //     this cleanup, and the pump's POSIX read() never sees EOF.
+    //     Joining would hang forever. Detach as in the orphan case;
+    //     the pump exits naturally when the successor eventually
+    //     closes its inherited fd (or zonvie exits first).
     //
-    // For the orphan path we must call detachFromCore() BEFORE the
+    // For both detach paths we must call detachFromCore() BEFORE the
     // pump might dereference Core, since Core may be torn down while
     // the pump is still running. detachFromCore() takes the pump's
-    // own mutex, waiting for any in-flight Core access to finish, then
-    // nulls the pump's back-pointer to Core. Subsequent iterations
-    // see core==null and skip every Core dereference.
-    if (orphan_child) {
-        // Orphan path: the pump thread keeps running until the
-        // orphan eventually closes its stderr writer (or never, if
-        // zonvie exits first). Drop our ref so the pump destroys
-        // itself when its thread releases its ref. detachFromCore
-        // first under the pump's mutex so the running pump stops
-        // dereferencing Core; then release() drops Core's ref.
-        // Both calls require a live ref, which we hold until the
-        // matched release().
+    // own mutex, waiting for any in-flight Core access to finish,
+    // then nulls the pump's back-pointer to Core. Subsequent
+    // iterations see core==null and skip every Core dereference.
+    const detach_pump = orphan_child or self.restart_pending_addr != null;
+    if (detach_pump) {
+        // Drop our ref so the pump destroys itself when its thread
+        // releases its ref. detachFromCore first under the pump's
+        // mutex so the running pump stops dereferencing Core; then
+        // release() drops Core's ref. Both calls require a live ref,
+        // which we hold until the matched release().
+        self.log.write("cleanupSession: stderr pump path=detach (orphan={any} restart_pending={any})\n", .{
+            orphan_child,
+            self.restart_pending_addr != null,
+        });
         if (self.stderr_pump) |p| {
             p.detachFromCore();
             p.release();
@@ -2064,18 +2102,25 @@ fn cleanupSession(
             t.detach();
             self.stderr_thread = null;
         }
+        self.log.write("cleanupSession: stderr pump detached\n", .{});
     } else {
-        // Normal path: child died, stderr writer closed, pump
-        // thread observed EOF and exited (releasing its ref).
+        // Final-shutdown path: child died, stderr writer closed,
+        // pump thread observed EOF and exited (releasing its ref).
         // join() guarantees the thread has finished its release;
         // we then drop Core's ref to free the struct.
+        self.log.write("cleanupSession: stderr pump path=join (thread_present={any} pump_present={any})\n", .{
+            self.stderr_thread != null,
+            self.stderr_pump != null,
+        });
         if (self.stderr_thread) |t| {
             t.join();
             self.stderr_thread = null;
+            self.log.write("cleanupSession: stderr thread joined\n", .{});
         }
         if (self.stderr_pump) |p| {
             p.release();
             self.stderr_pump = null;
+            self.log.write("cleanupSession: stderr pump released\n", .{});
         }
     }
 
@@ -2089,9 +2134,11 @@ fn cleanupSession(
     // their HANDLE references being yanked from under them. destroy()
     // closes those HANDLEs and frees the wrapper struct.
     if (self.session_pipe) |p| {
+        self.log.write("cleanupSession: destroying session_pipe (Windows named pipe wrapper)\n", .{});
         p.destroy();
         self.session_pipe = null;
     }
 
+    self.log.write("cleanupSession: returning (term_present={any})\n", .{session_term != null});
     return session_term;
 }

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -1780,6 +1780,14 @@ fn cleanupSession(
     const orphan_child = self.connect_keeps_child_alive;
 
     if (self.stdin_file) |f| {
+        // POSIX socket transport aliases stdin/stdout on the same fd.
+        // Issue shutdown(SHUT_RDWR) before close() so the writer
+        // thread (blocked in writeAll on the socket) returns EPIPE
+        // and exits — close() alone leaves it stuck, and the
+        // wt.join() below would hang. The reader does not run here
+        // (we are on the runLoop thread, post inner-loop exit), so
+        // it is naturally not affected.
+        f.shutdownIfSocket(self.transport_kind == .socket);
         f.close();
         self.stdin_file = null;
         // Socket transport aliases stdin and stdout on the same fd —

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -1281,6 +1281,15 @@ pub fn runLoop(self: *Core) void {
     // across iterations untouched, so the user sees no flicker on `:restart`.
     var ui_attached_overall: bool = false;
     var last_term: ?std.process.Child.Term = null;
+    // Set true on any session-fatal failure path that breaks :session
+    // without producing a usable last_term. Covers connect failures
+    // (remote :connect, connect-only mode, hot-swap fallback skip),
+    // spawn failure, ui_attach send failure, transport init failure.
+    // The on_exit code path below uses this to override the
+    // ui_attached_overall=true → exit 0 default — once a session has
+    // attached at least once, a later attach/connect failure would
+    // otherwise look like a clean exit to scripts wrapping zonvie.
+    var session_failed: bool = false;
 
     session: while (true) {
         var session_addr: ?[]u8 = null;
@@ -1307,6 +1316,7 @@ pub fn runLoop(self: *Core) void {
                     // instead.
                     self.log.write("connect: remote-mode :connect cannot reach new server's listen socket and old nvim is orphaned; not spawning surprise replacement; exiting run loop (addr={s})\n", .{a});
                     self.alloc.free(a);
+                    session_failed = true;
                     break :session;
                 }
                 self.log.write("restart: remote mode, re-spawning instead of connecting (addr={s})\n", .{a});
@@ -1355,6 +1365,7 @@ pub fn runLoop(self: *Core) void {
                 // argv to fall back to. Exit cleanly without spawning a
                 // surprise local nvim.
                 self.log.write("connect: no spawn fallback (connect-only mode); exiting run loop\n", .{});
+                session_failed = true;
                 break :session;
             } else if (was_connect_hotswap) {
                 // `:connect` hot-swap: the old nvim is already orphaned
@@ -1366,6 +1377,7 @@ pub fn runLoop(self: *Core) void {
                 // Exit cleanly so the frontend (via on_exit) can surface
                 // the failure instead.
                 self.log.write("connect: :connect hot-swap connect failed and old nvim is orphaned; not spawning surprise local fallback; exiting run loop\n", .{});
+                session_failed = true;
                 break :session;
             } else {
                 use_connect = false; // fall through to spawn
@@ -1405,6 +1417,7 @@ pub fn runLoop(self: *Core) void {
                     const msg_err = "[DIRECT] spawn error occurred\n";
                     logfn(self.ctx, msg_err.ptr, msg_err.len);
                 }
+                session_failed = true;
                 break :session;
             };
             const spawn_end_ns = std.time.nanoTimestamp();
@@ -1522,6 +1535,7 @@ pub fn runLoop(self: *Core) void {
         self.requestUiAttach(self.ui_attach_rows, self.ui_attach_cols) catch |e| {
             self.log.write("ui_attach send failed: {any}\n", .{e});
             _ = cleanupSession(self, &child, have_child, true, false);
+            session_failed = true;
             break :session;
         };
         ui_attached = true;
@@ -1551,12 +1565,14 @@ pub fn runLoop(self: *Core) void {
         if (self.stdout_file == null) {
             self.log.write("read transport is null\n", .{});
             _ = cleanupSession(self, &child, have_child, true, false);
+            session_failed = true;
             break :session;
         }
 
         var fr = FrameReader.init(self.alloc, self.stdout_file.?) catch |e| {
             self.log.write("FrameReader init failed: {any}\n", .{e});
             _ = cleanupSession(self, &child, have_child, true, false);
+            session_failed = true;
             break :session;
         };
         defer fr.deinit();
@@ -1695,12 +1711,19 @@ pub fn runLoop(self: *Core) void {
     if (!self.stop_flag.load(.seq_cst)) {
         if (self.cb.on_exit) |f| {
             // Convert Term to exit code:
+            //   - session_failed (any session-fatal break path that is
+            //     NOT a clean child exit): 1. Checked first so a hot-
+            //     swap connect failure on an already-attached session
+            //     does not look like a clean exit just because
+            //     ui_attached_overall is true.
             //   - Exited: use exit code directly
             //   - Signal: 128 + signal number (Unix convention)
             //   - Stopped/Unknown: return 1 (generic error)
             //   - Natural exit in connect mode (no Term, ui attached): 0
             //   - Pre-attach failure (no Term, never attached): 1
-            const exit_code: i32 = if (last_term) |t| switch (t) {
+            const exit_code: i32 = if (session_failed)
+                1
+            else if (last_term) |t| switch (t) {
                 .Exited => |code| @intCast(code),
                 .Signal => |sig| 128 + @as(i32, @intCast(sig)),
                 .Stopped, .Unknown => 1,

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -239,29 +239,110 @@ pub const CwdOwner = struct {
     }
 };
 
-pub fn pumpStderr(self: *Core, f: rpc_transport.Stream) void {
-    var buf: [4096]u8 = undefined;
-    while (!self.stop_flag.load(.seq_cst)) {
-        const n = f.read(&buf) catch break;
-        if (n == 0) break;
+/// Heap-allocated stderr pump state, refcount-managed so Core and the
+/// pump thread can release their references independently. This
+/// matters for the `:connect` orphan path: the old nvim keeps its
+/// stderr writer open after we hot-swap, our blocked POSIX read does
+/// not wake when we close our copy of the fd from cleanupSession, so
+/// the pump must run detached until the orphan eventually closes
+/// stderr — which can outlive Core itself if zonvie quits before the
+/// orphan does. At the same time, the pump can exit at ANY moment
+/// (orphan dies before cleanupSession reaches detachFromCore), so a
+/// raw self-destroy in run()'s defer would race Core's pointer use.
+///
+/// Lifetime contract:
+///   - At spawn, refcount = 2: one ref for Core (held via
+///     Core.stderr_pump), one ref for the pump thread.
+///   - Each holder calls release() exactly once when done. The last
+///     release closes f and frees the struct.
+///   - Core MUST keep its ref live across any access to the struct
+///     (detachFromCore, etc.) and call release() afterwards. Orphan
+///     path: detachFromCore + release; non-orphan: thread.join (which
+///     drops the thread's ref) then Core's release.
+///
+/// Core access (the `core` pointer) is gated by `mu`.
+/// cleanupSession's orphan path calls detachFromCore() (which holds
+/// mu while nulling the back-pointer) before letting Core go away;
+/// subsequent pump iterations see core==null inside the lock and skip
+/// every dereference. The mutex being inside the heap struct (not in
+/// Core) is what makes this safe — it outlives Core for the duration
+/// of the detached pump.
+///
+/// `alloc` MUST outlive every release(). Callers pass
+/// std.heap.c_allocator (process-lifetime) instead of CoreBox's GPA
+/// so a detached pump's eventual destroy still targets a valid
+/// allocator after zonvie_core_destroy has done box.gpa.deinit().
+pub const StderrPump = struct {
+    alloc: std.mem.Allocator,
+    f: rpc_transport.Stream,
+    mu: std.Thread.Mutex,
+    core: ?*Core,
+    refcount: std.atomic.Value(u32),
 
-        // Log stderr output
-        if (self.cb.on_log) |logfn| logfn(self.ctx, buf[0..n].ptr, n);
+    /// Drop one reference. When the count drops to zero, close the
+    /// fd and free the struct. Safe to call from any thread.
+    pub fn release(self: *StderrPump) void {
+        const prev = self.refcount.fetchSub(1, .acq_rel);
+        if (prev == 1) {
+            self.f.close();
+            self.alloc.destroy(self);
+        }
+    }
 
-        // SSH mode: detect password prompt in stderr
-        if (self.is_ssh_mode and !self.ssh_auth_done.load(.seq_cst)) {
-            const data = buf[0..n];
-            // Check for common password prompts (case-insensitive check for "password")
-            if (containsPasswordPrompt(data)) {
-                self.log.write("SSH: detected password prompt in stderr\n", .{});
-                if (self.cb.on_ssh_auth_prompt) |cb| {
-                    self.ssh_auth_pending.store(true, .seq_cst);
-                    cb(self.ctx, "SSH Password:", 13);
+    /// Run the pump until EOF / read error. Called from the pump
+    /// thread; never directly. Drops the thread's ref on exit.
+    pub fn run(self: *StderrPump) void {
+        defer self.release();
+        var buf: [4096]u8 = undefined;
+        while (true) {
+            // Stop check: Core may have flagged termination.
+            {
+                self.mu.lock();
+                defer self.mu.unlock();
+                if (self.core) |c| {
+                    if (c.stop_flag.load(.seq_cst)) break;
+                }
+            }
+
+            const n = self.f.read(&buf) catch break;
+            if (n == 0) break;
+
+            // Logging + SSH detection. Both touch Core, so guarded
+            // by the same mutex. After detachFromCore() this branch
+            // is a no-op — orphaned pumps simply discard the data.
+            // (We could keep logging via a captured on_log function
+            // pointer + ctx — both App-owned, safe across Core
+            // teardown — but that adds another snapshot field for
+            // a feature the orphan path does not need.)
+            self.mu.lock();
+            defer self.mu.unlock();
+            if (self.core) |c| {
+                if (c.cb.on_log) |logfn| logfn(c.ctx, buf[0..n].ptr, n);
+
+                if (c.is_ssh_mode and !c.ssh_auth_done.load(.seq_cst)) {
+                    if (containsPasswordPrompt(buf[0..n])) {
+                        c.log.write("SSH: detected password prompt in stderr\n", .{});
+                        if (c.cb.on_ssh_auth_prompt) |prompt_cb| {
+                            c.ssh_auth_pending.store(true, .seq_cst);
+                            prompt_cb(c.ctx, "SSH Password:", 13);
+                        }
+                    }
                 }
             }
         }
     }
-}
+
+    /// Sever the pump's back-reference to Core under the pump's own
+    /// mutex. After this returns, the pump will not dereference Core
+    /// in any subsequent iteration, and the caller is free to deinit
+    /// Core. Safe to call from any thread; caller MUST hold a ref to
+    /// the pump for the duration of this call.
+    pub fn detachFromCore(self: *StderrPump) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.core = null;
+    }
+};
 
 /// Check if data contains a password prompt (case-insensitive)
 pub fn containsPasswordPrompt(data: []const u8) bool {
@@ -1443,7 +1524,55 @@ pub fn runLoop(self: *Core) void {
             have_child = true;
 
             if (self.stderr_file) |ef| {
-                self.stderr_thread = std.Thread.spawn(.{}, pumpStderr, .{ self, ef }) catch null;
+                // Allocate the pump state on the heap so it can outlive
+                // Core (orphan path). Pump thread frees it on exit.
+                //
+                // Use std.heap.c_allocator instead of self.alloc here:
+                // an orphan-detached pump can still be running when
+                // zonvie_core_destroy calls box.gpa.deinit(), at which
+                // point self.alloc would be a dead allocator interface.
+                // c_allocator is process-lifetime, so the pump's later
+                // self.alloc.destroy(self) is always safe.
+                const pump_alloc = std.heap.c_allocator;
+                const pump = pump_alloc.create(StderrPump) catch null;
+                if (pump) |p| {
+                    p.* = .{
+                        .alloc = pump_alloc,
+                        .f = ef,
+                        .mu = .{},
+                        .core = self,
+                        // refcount = 2 from the start: one for Core
+                        // (kept via self.stderr_pump until cleanup
+                        // calls release), one for the pump thread
+                        // (released by run()'s defer). Pre-set so the
+                        // thread can't observe a stale 0.
+                        .refcount = std.atomic.Value(u32).init(2),
+                    };
+                    self.stderr_pump = p;
+                    self.stderr_thread = std.Thread.spawn(.{}, StderrPump.run, .{p}) catch blk: {
+                        // Spawn failed: thread never started so it
+                        // never took its ref. We are the only holder;
+                        // free the struct and close the fd directly,
+                        // no need to go through release().
+                        p.f.close();
+                        pump_alloc.destroy(p);
+                        self.stderr_pump = null;
+                        break :blk null;
+                    };
+                } else {
+                    // Allocation failed: nothing else owns this fd
+                    // (child.stderr is already null after the ownership
+                    // transfer above), so close it here. cleanupSession
+                    // assumes the pump owns the fd and would only null
+                    // self.stderr_file without closing.
+                    ef.close();
+                }
+                // Ownership of stderr_file has been transferred:
+                //   - alloc + spawn ok: pump owns; freed by run()'s defer.
+                //   - spawn failed: catch above closed and freed pump.
+                //   - alloc failed: closed in the else branch above.
+                // In all cases Core no longer holds the fd.
+                self.stderr_file = null;
             }
 
             // SSH mode defers writer thread until after authentication completes.
@@ -1886,21 +2015,68 @@ fn cleanupSession(
         }
     }
 
-    // Close any remaining transport handles.
+    // Close any remaining transport handles. stderr_file is intentionally
+    // NOT closed here — its fd is owned by pumpStderr (which defer-closes
+    // on exit), so closing from this thread risks fd reuse if the pump's
+    // blocked read syscall hasn't yet observed EOF and the fd number is
+    // recycled by the next open() in our process. Just null the alias.
     if (self.stdout_file) |f| {
         f.close();
         self.stdout_file = null;
     }
-    if (self.stderr_file) |f| {
-        f.close();
-        self.stderr_file = null;
-    }
+    self.stderr_file = null;
 
-    // Join the stderr pump (if any). Closing stderr_file above causes
-    // its read() to return 0, exiting the thread cleanly.
-    if (self.stderr_thread) |t| {
-        t.join();
-        self.stderr_thread = null;
+    // Reap the stderr pump.
+    //   - Normal path: child died, its stderr writer closed, our pump
+    //     read returned 0, the pump thread is exiting (or already
+    //     exited). join() completes promptly.
+    //   - Orphan path (`:connect` hot-swap): the old nvim is still
+    //     running and holds the stderr writer open, so the pump is
+    //     stuck in a blocking read that close() on the read end does
+    //     NOT wake on POSIX. Joining would hang the run loop and
+    //     prevent attaching to the new server. Detach instead — the
+    //     pump exits naturally when the orphan eventually closes its
+    //     stderr (process exit, :connect! from another UI, etc.) and
+    //     the defer in StderrPump.run releases the fd and frees the
+    //     pump struct.
+    //
+    // For the orphan path we must call detachFromCore() BEFORE the
+    // pump might dereference Core, since Core may be torn down while
+    // the pump is still running. detachFromCore() takes the pump's
+    // own mutex, waiting for any in-flight Core access to finish, then
+    // nulls the pump's back-pointer to Core. Subsequent iterations
+    // see core==null and skip every Core dereference.
+    if (orphan_child) {
+        // Orphan path: the pump thread keeps running until the
+        // orphan eventually closes its stderr writer (or never, if
+        // zonvie exits first). Drop our ref so the pump destroys
+        // itself when its thread releases its ref. detachFromCore
+        // first under the pump's mutex so the running pump stops
+        // dereferencing Core; then release() drops Core's ref.
+        // Both calls require a live ref, which we hold until the
+        // matched release().
+        if (self.stderr_pump) |p| {
+            p.detachFromCore();
+            p.release();
+            self.stderr_pump = null;
+        }
+        if (self.stderr_thread) |t| {
+            t.detach();
+            self.stderr_thread = null;
+        }
+    } else {
+        // Normal path: child died, stderr writer closed, pump
+        // thread observed EOF and exited (releasing its ref).
+        // join() guarantees the thread has finished its release;
+        // we then drop Core's ref to free the struct.
+        if (self.stderr_thread) |t| {
+            t.join();
+            self.stderr_thread = null;
+        }
+        if (self.stderr_pump) |p| {
+            p.release();
+            self.stderr_pump = null;
+        }
     }
 
     // All threads that could dereference the Windows named-pipe wrapper

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -1284,9 +1284,30 @@ pub fn runLoop(self: *Core) void {
     session: while (true) {
         var session_addr: ?[]u8 = null;
         var use_connect: bool = false;
+        // Snapshot whether the pending session was queued by `:connect`
+        // (hot-swap, old nvim orphaned) vs `:restart` (old nvim dead).
+        // Consumed below so a subsequent fall-through to spawn doesn't
+        // see stale state.
+        var was_connect_hotswap: bool = false;
         if (self.restart_pending_addr) |a| {
             self.restart_pending_addr = null;
+            was_connect_hotswap = self.restart_pending_is_connect_hotswap;
+            self.restart_pending_is_connect_hotswap = false;
             if (is_remote_for_restart) {
+                if (was_connect_hotswap) {
+                    // Remote-mode `:connect` hot-swap: the new server's
+                    // listen socket lives inside the SSH / WSL /
+                    // devcontainer / shell wrapper and is not reachable
+                    // from the host, so we can't attach. The old nvim has
+                    // already been orphaned by cleanup, so falling through
+                    // to spawn the original argv would launch a wholly new
+                    // remote session unrelated to the user's editing state
+                    // in the orphan. Surface the failure via on_exit
+                    // instead.
+                    self.log.write("connect: remote-mode :connect cannot reach new server's listen socket and old nvim is orphaned; not spawning surprise replacement; exiting run loop (addr={s})\n", .{a});
+                    self.alloc.free(a);
+                    break :session;
+                }
                 self.log.write("restart: remote mode, re-spawning instead of connecting (addr={s})\n", .{a});
                 self.alloc.free(a);
             } else {
@@ -1312,12 +1333,38 @@ pub fn runLoop(self: *Core) void {
                 self.stdin_file = conn;
                 self.stdout_file = conn; // alias of the same fd / pipe wrapper
                 self.stderr_file = null;
+                // For Windows named pipes the Stream wraps a heap-allocated
+                // *WindowsOverlappedPipe. Save the owning pointer so we can
+                // destroy() the wrapper *after* the writer/stderr threads
+                // have been joined — Stream.close() only fires CancelIoEx
+                // on the pipe HANDLE (no HANDLE close yet) so blocked
+                // GetOverlappedResult calls return without their HANDLE
+                // references being closed mid-wait. The pipe HANDLE, the
+                // event HANDLEs, and the wrapper memory are all released
+                // together by destroy(). Without this separate ownership
+                // pointer, the alias-null in stop()/cleanupSession would
+                // drop our only reference and the wrapper would leak.
+                self.session_pipe = switch (conn) {
+                    .win_pipe => |p| p,
+                    .file => null,
+                };
                 self.log.write("connect: established socket session to {s}\n", .{session_addr.?});
             } else if (nvim_path.len == 0) {
                 // Connect-only mode (started via zonvie_core_start_connect): no
                 // argv to fall back to. Exit cleanly without spawning a
                 // surprise local nvim.
                 self.log.write("connect: no spawn fallback (connect-only mode); exiting run loop\n", .{});
+                break :session;
+            } else if (was_connect_hotswap) {
+                // `:connect` hot-swap: the old nvim is already orphaned
+                // (kept alive headless on its own listen socket — the user
+                // can still reach it manually). Falling through to spawn
+                // the original argv would open a brand-new local nvim
+                // session that is unrelated to the user's editing state in
+                // the orphan, leaving them with TWO disconnected sessions.
+                // Exit cleanly so the frontend (via on_exit) can surface
+                // the failure instead.
+                self.log.write("connect: :connect hot-swap connect failed and old nvim is orphaned; not spawning surprise local fallback; exiting run loop\n", .{});
                 break :session;
             } else {
                 use_connect = false; // fall through to spawn
@@ -1424,7 +1471,7 @@ pub fn runLoop(self: *Core) void {
 
                 if (self.stop_flag.load(.seq_cst)) {
                     self.log.write("SSH mode: stopped by user\n", .{});
-                    teardownSpawnSession(self, &child, have_child);
+                    _ = cleanupSession(self, &child, have_child, false);
                     break :session;
                 }
             }
@@ -1449,7 +1496,7 @@ pub fn runLoop(self: *Core) void {
         }
 
         if (self.stop_flag.load(.seq_cst)) {
-            teardownSpawnSession(self, &child, have_child);
+            _ = cleanupSession(self, &child, have_child, false);
             break :session;
         }
 
@@ -1473,7 +1520,7 @@ pub fn runLoop(self: *Core) void {
 
         self.requestUiAttach(self.ui_attach_rows, self.ui_attach_cols) catch |e| {
             self.log.write("ui_attach send failed: {any}\n", .{e});
-            teardownSpawnSession(self, &child, have_child);
+            _ = cleanupSession(self, &child, have_child, true);
             break :session;
         };
         ui_attached = true;
@@ -1502,13 +1549,13 @@ pub fn runLoop(self: *Core) void {
 
         if (self.stdout_file == null) {
             self.log.write("read transport is null\n", .{});
-            teardownSpawnSession(self, &child, have_child);
+            _ = cleanupSession(self, &child, have_child, true);
             break :session;
         }
 
         var fr = FrameReader.init(self.alloc, self.stdout_file.?) catch |e| {
             self.log.write("FrameReader init failed: {any}\n", .{e});
-            teardownSpawnSession(self, &child, have_child);
+            _ = cleanupSession(self, &child, have_child, true);
             break :session;
         };
         defer fr.deinit();
@@ -1583,80 +1630,11 @@ pub fn runLoop(self: *Core) void {
         }
 
         // === Session cleanup ===
-        // Stop the writer thread before closing the transport so its
-        // in-flight writeAll() doesn't observe a torn-down handle.
-        var wt: ?std.Thread = null;
-        {
-            self.write_queue_mu.lock();
-            self.write_queue_closed = true;
-            wt = self.writer_thread;
-            self.writer_thread = null;
-            self.write_queue_cond.signal();
-            self.write_queue_mu.unlock();
-        }
-        // `:connect` hot-swap: the old nvim is still alive headless on
-        // its own listen socket and would block child.wait() forever
-        // (the process never exits). Don't kill, don't wait — just drop
-        // the handle. The orphan continues running until the user kills
-        // it manually. We still close OUR end of the pipes (just FDs in
-        // our process; doesn't affect the running nvim).
-        const orphan_child = self.connect_keeps_child_alive;
-
-        if (self.stdin_file) |f| {
-            f.close();
-            self.stdin_file = null;
-            // Socket transport aliases stdin and stdout on the same fd —
-            // closing once fully tears down the connection. Null both
-            // pointers so downstream cleanup does not double-close.
-            if (self.transport_kind == .socket) {
-                self.stdout_file = null;
-            }
-        }
-        if (wt) |t| t.join();
-
-        // Wait for the child (spawn mode only) and capture exit term.
-        var session_term: ?std.process.Child.Term = null;
-        if (have_child) {
-            if (orphan_child) {
-                self.log.write("orphaning headless nvim (pid={any}) for :connect hot-swap\n", .{child.id});
-                self.child_handle = null;
-            } else {
-                // User stop OR restart/connect queued via the inner-loop
-                // early break: kill the child to ensure it terminates
-                // promptly. For local spawn the child is usually already
-                // dead (nvim self-exits on :restart); kill is then a
-                // no-op. For SSH / devcontainer / WSL the wrapper
-                // process is still alive holding stdio open, and would
-                // make child.wait() block indefinitely without this kill.
-                if (self.stop_flag.load(.seq_cst) or self.restart_pending_addr != null) {
-                    _ = child.kill() catch {};
-                }
-                session_term = child.wait() catch |e| blk: {
-                    self.log.write("wait err: {any}\n", .{e});
-                    break :blk null;
-                };
-                if (session_term) |t| self.log.write("nvim terminated: {any}\n", .{t});
-                self.child_handle = null;
-            }
-        }
-        if (session_term) |t| last_term = t;
-
-        // Close any remaining transport handles.
-        if (self.stdout_file) |f| {
-            f.close();
-            self.stdout_file = null;
-        }
-        if (self.stderr_file) |f| {
-            f.close();
-            self.stderr_file = null;
-        }
-
-        // Join the stderr pump (if any). Closing stderr_file above causes
-        // its read() to return 0, exiting the thread cleanly.
-        if (self.stderr_thread) |t| {
-            t.join();
-            self.stderr_thread = null;
-        }
+        // Natural inner-loop exit: kill conditions inside cleanupSession
+        // already cover stop_flag and restart_pending_addr, so no need to
+        // force-kill here. Propagate the term so on_exit can compute the
+        // right exit code from how nvim ended this session.
+        if (cleanupSession(self, &child, have_child, false)) |t| last_term = t;
 
         // === Decide next iteration ===
         if (self.stop_flag.load(.seq_cst)) {
@@ -1706,13 +1684,118 @@ pub fn runLoop(self: *Core) void {
     }
 }
 
-/// Tear down a partially-set-up spawn session without firing on_exit.
-/// Called from early-exit paths inside runLoop (ui_attach failure, stop
-/// during ssh-auth wait, etc.). Safe to call when have_child is false.
-fn teardownSpawnSession(self: *Core, child: *std.process.Child, have_child: bool) void {
-    if (have_child) {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        self.child_handle = null;
+/// Tear down the current RPC session: stop the writer thread, close the
+/// transport (with socket-alias handling), reap the child (if any), and
+/// join the stderr pump. Safe to call from any session-exit path — both
+/// the natural inner-loop exit and the early-exit failure paths
+/// (ui_attach failure, FrameReader init failure, stop during ssh-auth,
+/// etc.). Safe to call when have_child is false.
+///
+/// `force_kill_child`: when true, unconditionally kill the child before
+/// wait(). Used by early-exit failure paths that do not set stop_flag /
+/// restart_pending_addr but still need the child to terminate promptly
+/// so wait() does not block (notably SSH / devcontainer / WSL where the
+/// wrapper holds stdio open until killed).
+///
+/// Returns the child's exit term, or null if not available (no child,
+/// orphaned for a `:connect` hot-swap, or wait() failed). The caller
+/// decides whether to propagate the term to `last_term` for on_exit's
+/// exit-code computation.
+fn cleanupSession(
+    self: *Core,
+    child: *std.process.Child,
+    have_child: bool,
+    force_kill_child: bool,
+) ?std.process.Child.Term {
+    // Stop the writer thread before closing the transport so its
+    // in-flight writeAll() does not observe a torn-down handle.
+    var wt: ?std.Thread = null;
+    {
+        self.write_queue_mu.lock();
+        self.write_queue_closed = true;
+        wt = self.writer_thread;
+        self.writer_thread = null;
+        self.write_queue_cond.signal();
+        self.write_queue_mu.unlock();
     }
+    // `:connect` hot-swap: the old nvim is still alive headless on
+    // its own listen socket and would block child.wait() forever
+    // (the process never exits). Don't kill, don't wait — just drop
+    // the handle. The orphan continues running until the user kills
+    // it manually. We still close OUR end of the pipes (just FDs in
+    // our process; doesn't affect the running nvim).
+    const orphan_child = self.connect_keeps_child_alive;
+
+    if (self.stdin_file) |f| {
+        f.close();
+        self.stdin_file = null;
+        // Socket transport aliases stdin and stdout on the same fd —
+        // closing once fully tears down the connection. Null both
+        // pointers so downstream cleanup does not double-close.
+        if (self.transport_kind == .socket) {
+            self.stdout_file = null;
+        }
+    }
+    if (wt) |t| t.join();
+
+    var session_term: ?std.process.Child.Term = null;
+    if (have_child) {
+        if (orphan_child) {
+            self.log.write("orphaning headless nvim (pid={any}) for :connect hot-swap\n", .{child.id});
+            self.child_handle = null;
+        } else {
+            // Kill conditions:
+            //   - User stop OR restart/connect queued via inner-loop early
+            //     break: terminate promptly. For local spawn the child is
+            //     usually already dead (nvim self-exits on :restart); kill
+            //     is then a no-op. For SSH / devcontainer / WSL the wrapper
+            //     process is still alive holding stdio open, and would make
+            //     child.wait() block indefinitely without this kill.
+            //   - force_kill_child: early-exit failure paths haven't set
+            //     stop_flag, but still need the child reaped without
+            //     blocking on wait().
+            if (force_kill_child or self.stop_flag.load(.seq_cst) or self.restart_pending_addr != null) {
+                _ = child.kill() catch {};
+            }
+            session_term = child.wait() catch |e| blk: {
+                self.log.write("wait err: {any}\n", .{e});
+                break :blk null;
+            };
+            if (session_term) |t| self.log.write("nvim terminated: {any}\n", .{t});
+            self.child_handle = null;
+        }
+    }
+
+    // Close any remaining transport handles.
+    if (self.stdout_file) |f| {
+        f.close();
+        self.stdout_file = null;
+    }
+    if (self.stderr_file) |f| {
+        f.close();
+        self.stderr_file = null;
+    }
+
+    // Join the stderr pump (if any). Closing stderr_file above causes
+    // its read() to return 0, exiting the thread cleanly.
+    if (self.stderr_thread) |t| {
+        t.join();
+        self.stderr_thread = null;
+    }
+
+    // All threads that could dereference the Windows named-pipe wrapper
+    // (writer thread, stderr pump, the run-loop reader inlined above)
+    // have now been joined — safe to release the kernel HANDLEs and
+    // free the heap allocation. Stream.close() above only canceled
+    // pending I/O via CancelIoEx; the pipe HANDLE and the event
+    // HANDLEs stayed alive until now so that threads sleeping in
+    // GetOverlappedResult could wake up and exit cleanly without
+    // their HANDLE references being yanked from under them. destroy()
+    // closes those HANDLEs and frees the wrapper struct.
+    if (self.session_pipe) |p| {
+        p.destroy();
+        self.session_pipe = null;
+    }
+
+    return session_term;
 }

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -14,6 +14,7 @@ const flush = @import("flush.zig");
 const nvim_core = @import("nvim_core.zig");
 const Core = nvim_core.Core;
 const Callbacks = nvim_core.Callbacks;
+const rpc_transport = @import("rpc_transport.zig");
 
 pub const PipeReader = struct {
     file: std.fs.File,
@@ -780,6 +781,8 @@ pub fn handleRpcNotification(self: *Core, arena: std.mem.Allocator, top: []mp.Va
             flush.FlushCtx.onLinespace,
             flush.FlushCtx.onSetTitle,
             flush.FlushCtx.onDefaultColors,
+            flush.FlushCtx.onRestart,
+            flush.FlushCtx.onConnect,
         ) catch |re| {
             self.log.write("redraw err: {any}\n", .{re});
         };
@@ -1122,6 +1125,15 @@ pub fn runLoop(self: *Core) void {
         contains_ssh_exe or
         (is_cmd and std.mem.indexOf(u8, nvim_path, "ssh") != null);
 
+    // Remote modes wrap nvim in an indirection (ssh / devcontainer / wsl /
+    // shell / cmd). The listen_addr returned by a `:restart` event lives
+    // inside that indirection and is not reachable from the host, so a
+    // restart in remote mode falls back to re-spawn instead of socket
+    // connect. Pure native sessions (and any future "connect to running
+    // nvim" entry point) get the proper transparent reconnect.
+    const is_remote_for_restart = is_wsl or is_ssh or is_ssh_askpass or
+        is_cmd or is_shell or is_devcontainer;
+
     // Buffer for parsed arguments
     var argv_buf: [16][]const u8 = undefined;
     var argc: usize = 0;
@@ -1254,314 +1266,433 @@ pub fn runLoop(self: *Core) void {
     logEnvHints(self);
     self.log.write("[MARKER] after logEnvHints\n", .{});
 
-    var child = std.process.Child.init(argv_buf[0..argc], self.alloc);
-    child.stdin_behavior = .Pipe;
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-    child.create_no_window = true;
+    // === Session loop ===
+    //
+    // First iteration spawns nvim (or, in the future, opens an initial
+    // socket connection — currently not yet a separate entry point).
+    // Subsequent iterations are entered only when a `:restart` event
+    // queued `restart_pending_addr`. In that case:
+    //   - Native mode:   open a socket to listen_addr (transparent reconnect).
+    //   - Remote mode:   re-spawn the same argv (listen_addr unreachable).
+    //   - Connect failure: same as remote — fall back to re-spawn.
+    //
+    // Persistent state (grid, hl, atlas, ext UI, layout dimensions) carries
+    // across iterations untouched, so the user sees no flicker on `:restart`.
+    var ui_attached_overall: bool = false;
+    var last_term: ?std.process.Child.Term = null;
 
-    var cwd_owner: CwdOwner = .{};
-    defer cwd_owner.close();
-    if (!self.inherit_cwd) {
-        cwd_owner.openPreferred(self.alloc, &self.log);
-        cwd_owner.applyToChild(&child);
-    } else {
-        self.log.write("inherit_cwd=true; child inherits parent cwd\n", .{});
-    }
-
-    // Check for path separators - both '/' (Unix) and '\' (Windows)
-    const has_slash = (std.mem.indexOfScalar(u8, nvim_path, '/') != null) or
-        (std.mem.indexOfScalar(u8, nvim_path, '\\') != null);
-    if (@hasField(@TypeOf(child), "expand_arg0")) {
-        child.expand_arg0 = if (has_slash) .no_expand else .expand;
-    }
-    self.log.write("expand_arg0: has_slash={}, mode={s}\n", .{ has_slash, if (has_slash) "no_expand" else "expand" });
-
-    self.log.write("about to spawn...\n", .{});
-    // Direct callback log before spawn
-    if (self.cb.on_log) |logfn| {
-        const msg1 = "[DIRECT] calling child.spawn() now\n";
-        logfn(self.ctx, msg1.ptr, msg1.len);
-    }
-    const spawn_start_ns = std.time.nanoTimestamp();
-    child.spawn() catch |e| {
-        self.log.write("spawn failed: {any}\n", .{e});
-        if (self.cb.on_log) |logfn| {
-            const msg_err = "[DIRECT] spawn error occurred\n";
-            logfn(self.ctx, msg_err.ptr, msg_err.len);
+    session: while (true) {
+        var session_addr: ?[]u8 = null;
+        var use_connect: bool = false;
+        if (self.restart_pending_addr) |a| {
+            self.restart_pending_addr = null;
+            if (is_remote_for_restart) {
+                self.log.write("restart: remote mode, re-spawning instead of connecting (addr={s})\n", .{a});
+                self.alloc.free(a);
+            } else {
+                session_addr = a;
+                use_connect = true;
+            }
         }
-        return;
-    };
-    const spawn_end_ns = std.time.nanoTimestamp();
-    const spawn_ms = @divTrunc(spawn_end_ns - spawn_start_ns, 1_000_000);
-    // Direct callback log after spawn
-    if (self.cb.on_log) |logfn| {
-        const msg2 = "[DIRECT] child.spawn() returned successfully\n";
-        logfn(self.ctx, msg2.ptr, msg2.len);
-    }
-    self.log.write("[TIMING] nvim spawn: {d}ms\n", .{spawn_ms});
-    self.log.write("spawn returned ok, pid={any}\n", .{child.id});
+        defer if (session_addr) |a| self.alloc.free(a);
 
-    // Note: Don't try to read stderr here - it blocks if no data available
+        // === Set up transport ===
+        var have_child: bool = false;
+        var child: std.process.Child = undefined;
+        var cwd_owner: CwdOwner = .{};
+        defer cwd_owner.close();
 
-    self.child_handle = child.id;
-    self.stdin_file = child.stdin;
-    self.stdout_file = child.stdout;
-    self.stderr_file = child.stderr;
+        if (use_connect) {
+            const conn_opt: ?rpc_transport.Connection = rpc_transport.connectListenAddr(self.alloc, session_addr.?) catch |e| blk: {
+                self.log.write("connect to {s} failed: {any}; falling back to re-spawn\n", .{ session_addr.?, e });
+                break :blk null;
+            };
+            if (conn_opt) |conn| {
+                self.transport_kind = .socket;
+                self.stdin_file = conn.file;
+                self.stdout_file = conn.file; // alias of the same fd
+                self.stderr_file = null;
+                self.log.write("connect: established socket session to {s}\n", .{session_addr.?});
+            } else if (nvim_path.len == 0) {
+                // Connect-only mode (started via zonvie_core_start_connect): no
+                // argv to fall back to. Exit cleanly without spawning a
+                // surprise local nvim.
+                self.log.write("connect: no spawn fallback (connect-only mode); exiting run loop\n", .{});
+                break :session;
+            } else {
+                use_connect = false; // fall through to spawn
+            }
+        }
 
-    // OWNERSHIP TRANSFER:
-    // We keep the pipe handles in Core, so prevent std.process.Child from closing them.
-    child.stdin = null;
-    child.stdout = null;
-    child.stderr = null;
+        if (!use_connect) {
+            child = std.process.Child.init(argv_buf[0..argc], self.alloc);
+            child.stdin_behavior = .Pipe;
+            child.stdout_behavior = .Pipe;
+            child.stderr_behavior = .Pipe;
+            child.create_no_window = true;
 
-    if (self.stderr_file) |ef| {
-        self.stderr_thread = std.Thread.spawn(.{}, pumpStderr, .{ self, ef }) catch null;
-    }
-
-    // Start writer thread for non-blocking stdin writes.
-    // SSH mode defers this until after authentication completes (see below).
-    if (!self.is_ssh_mode) {
-        self.startWriterThread();
-    }
-
-    // SSH mode: prompt for password immediately after process start
-    // With -tt option, password prompt goes to TTY (not visible via pipes)
-    // So we show dialog immediately and wait for user to enter password
-    if (self.is_ssh_mode) {
-        self.log.write("SSH mode: prompting for password immediately...\n", .{});
-
-        // Set pending flag to block other stdin writes (RPC sends)
-        self.ssh_auth_pending.store(true, .seq_cst);
-
-        // Small delay to let SSH start
-        std.Thread.sleep(200 * std.time.ns_per_ms);
-
-        // Call callback to show password dialog
-        if (self.cb.on_ssh_auth_prompt) |cb| {
-            cb(self.ctx, "SSH Password:", 13);
-
-            // Wait for password to be sent (ssh_auth_done flag)
-            self.log.write("SSH mode: waiting for user to enter password...\n", .{});
-            var waited_ms: u32 = 0;
-            const timeout_ms: u32 = 60000; // 60 seconds
-            const poll_ms: u32 = 100;
-
-            while (waited_ms < timeout_ms and !self.stop_flag.load(.seq_cst)) {
-                if (self.ssh_auth_done.load(.seq_cst)) {
-                    self.log.write("SSH mode: password sent, waiting for connection...\n", .{});
-                    // Give SSH time to authenticate
-                    std.Thread.sleep(2000 * std.time.ns_per_ms);
-                    break;
-                }
-                std.Thread.sleep(poll_ms * std.time.ns_per_ms);
-                waited_ms += poll_ms;
+            if (!self.inherit_cwd) {
+                cwd_owner.openPreferred(self.alloc, &self.log);
+                cwd_owner.applyToChild(&child);
+            } else {
+                self.log.write("inherit_cwd=true; child inherits parent cwd\n", .{});
             }
 
-            if (waited_ms >= timeout_ms) {
-                self.log.write("SSH mode: authentication timeout\n", .{});
+            const has_slash = (std.mem.indexOfScalar(u8, nvim_path, '/') != null) or
+                (std.mem.indexOfScalar(u8, nvim_path, '\\') != null);
+            if (@hasField(@TypeOf(child), "expand_arg0")) {
+                child.expand_arg0 = if (has_slash) .no_expand else .expand;
+            }
+            self.log.write("expand_arg0: has_slash={}, mode={s}\n", .{ has_slash, if (has_slash) "no_expand" else "expand" });
+
+            self.log.write("about to spawn...\n", .{});
+            if (self.cb.on_log) |logfn| {
+                const msg1 = "[DIRECT] calling child.spawn() now\n";
+                logfn(self.ctx, msg1.ptr, msg1.len);
+            }
+            const spawn_start_ns = std.time.nanoTimestamp();
+            child.spawn() catch |e| {
+                self.log.write("spawn failed: {any}\n", .{e});
+                if (self.cb.on_log) |logfn| {
+                    const msg_err = "[DIRECT] spawn error occurred\n";
+                    logfn(self.ctx, msg_err.ptr, msg_err.len);
+                }
+                break :session;
+            };
+            const spawn_end_ns = std.time.nanoTimestamp();
+            const spawn_ms = @divTrunc(spawn_end_ns - spawn_start_ns, 1_000_000);
+            if (self.cb.on_log) |logfn| {
+                const msg2 = "[DIRECT] child.spawn() returned successfully\n";
+                logfn(self.ctx, msg2.ptr, msg2.len);
+            }
+            self.log.write("[TIMING] nvim spawn: {d}ms\n", .{spawn_ms});
+            self.log.write("spawn returned ok, pid={any}\n", .{child.id});
+
+            self.transport_kind = .pipes;
+            self.child_handle = child.id;
+            self.stdin_file = child.stdin;
+            self.stdout_file = child.stdout;
+            self.stderr_file = child.stderr;
+
+            // OWNERSHIP TRANSFER: keep handles in Core; prevent Child from closing them.
+            child.stdin = null;
+            child.stdout = null;
+            child.stderr = null;
+
+            have_child = true;
+
+            if (self.stderr_file) |ef| {
+                self.stderr_thread = std.Thread.spawn(.{}, pumpStderr, .{ self, ef }) catch null;
+            }
+
+            // SSH mode defers writer thread until after authentication completes.
+            if (!self.is_ssh_mode) {
+                self.startWriterThread();
+            }
+
+            if (self.is_ssh_mode) {
+                self.log.write("SSH mode: prompting for password immediately...\n", .{});
+                self.ssh_auth_pending.store(true, .seq_cst);
+                std.Thread.sleep(200 * std.time.ns_per_ms);
+
+                if (self.cb.on_ssh_auth_prompt) |cb| {
+                    cb(self.ctx, "SSH Password:", 13);
+                    self.log.write("SSH mode: waiting for user to enter password...\n", .{});
+                    var waited_ms: u32 = 0;
+                    const timeout_ms: u32 = 60000;
+                    const poll_ms: u32 = 100;
+
+                    while (waited_ms < timeout_ms and !self.stop_flag.load(.seq_cst)) {
+                        if (self.ssh_auth_done.load(.seq_cst)) {
+                            self.log.write("SSH mode: password sent, waiting for connection...\n", .{});
+                            std.Thread.sleep(2000 * std.time.ns_per_ms);
+                            break;
+                        }
+                        std.Thread.sleep(poll_ms * std.time.ns_per_ms);
+                        waited_ms += poll_ms;
+                    }
+
+                    if (waited_ms >= timeout_ms) {
+                        self.log.write("SSH mode: authentication timeout\n", .{});
+                    }
+                } else {
+                    self.log.write("SSH mode: no callback registered\n", .{});
+                }
+
+                self.ssh_auth_pending.store(false, .seq_cst);
+                self.startWriterThread();
+
+                if (self.stop_flag.load(.seq_cst)) {
+                    self.log.write("SSH mode: stopped by user\n", .{});
+                    teardownSpawnSession(self, &child, have_child);
+                    break :session;
+                }
             }
         } else {
-            self.log.write("SSH mode: no callback registered\n", .{});
+            // Connect mode has no child process; the writer thread can
+            // start immediately (no SSH auth in this path).
+            self.startWriterThread();
         }
 
-        // Clear pending flag and start writer thread now that auth is done
-        self.ssh_auth_pending.store(false, .seq_cst);
-        self.startWriterThread();
+        var ui_attached: bool = false;
+
+        // Block until layout is ready (set by notifyLayoutReady on first
+        // start). For restart iterations ui_attach_ready is already true,
+        // so this falls through immediately.
+        {
+            self.ui_attach_mutex.lock();
+            defer self.ui_attach_mutex.unlock();
+            while (!self.ui_attach_ready) {
+                if (self.stop_flag.load(.seq_cst)) break;
+                self.ui_attach_cond.wait(&self.ui_attach_mutex);
+            }
+        }
 
         if (self.stop_flag.load(.seq_cst)) {
-            self.log.write("SSH mode: stopped by user\n", .{});
-            return;
+            teardownSpawnSession(self, &child, have_child);
+            break :session;
         }
-    }
 
-    var ui_attached = false;
+        self.log.write("[rpc] layout ready: rows={d} cols={d}, sending ui_attach\n", .{ self.ui_attach_rows, self.ui_attach_cols });
+        self.requestSetClientInfo() catch |e| self.log.write("send set_client_info failed: {any}\n", .{e});
 
-    // Block until layout is ready (ui_attach_cond signaled by notifyLayoutReady)
-    {
-        self.ui_attach_mutex.lock();
-        defer self.ui_attach_mutex.unlock();
-        while (!self.ui_attach_ready) {
-            if (self.stop_flag.load(.seq_cst)) break;
-            self.ui_attach_cond.wait(&self.ui_attach_mutex);
-        }
-    }
-
-    if (self.stop_flag.load(.seq_cst)) {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return;
-    }
-
-    self.log.write("[rpc] layout ready: rows={d} cols={d}, sending ui_attach\n", .{ self.ui_attach_rows, self.ui_attach_cols });
-    self.requestSetClientInfo() catch |e| self.log.write("send set_client_info failed: {any}\n", .{e});
-
-    // If config.toml [font] family is set, push it to nvim's `guifont` BEFORE
-    // ui_attach. Sending it after ui_attach would arrive mid-redraw: nvim
-    // would emit an option_set during its initial paint, then re-emit after
-    // processing our set. The second paint round-trip caused the statusline
-    // to briefly drop its text on Windows at startup.
-    if (self.msg_config.font.family_explicit) {
-        var guifont_buf: [256]u8 = undefined;
-        const guifont_str = std.fmt.bufPrint(&guifont_buf, "{s}:h{d}", .{
-            self.msg_config.font.family,
-            self.msg_config.font.size,
-        }) catch null;
-        if (guifont_str) |val| {
-            self.requestSetOptionValue("guifont", val) catch |e|
-                self.log.write("pre-attach set guifont failed: {any}\n", .{e});
-        }
-    }
-
-    self.requestUiAttach(self.ui_attach_rows, self.ui_attach_cols) catch |e| {
-        self.log.write("ui_attach send failed: {any}\n", .{e});
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return;
-    };
-    ui_attached = true;
-    self.ui_attached.store(true, .seq_cst);
-    self.flushPendingFocus();
-
-    // Setup clipboard immediately after ui_attach (no get_api_info
-    // round-trip). The Lua code discovers our channel_id via
-    // nvim_list_chans() + client.name match.
-    setupClipboard(self);
-
-    // Glow config is requested via glow_startup_retries during flush processing.
-
-    if (self.pending_resize_valid) {
-        const pr2 = self.pending_resize_rows;
-        const pc2 = self.pending_resize_cols;
-        if (pr2 == self.ui_attach_rows and pc2 == self.ui_attach_cols) {
-            self.pending_resize_valid = false;
-            self.log.write("pending resize skipped (same as attach size rows={d} cols={d})\n", .{ pr2, pc2 });
-        } else {
-            self.requestTryResize(pr2, pc2) catch |e| {
-                self.log.write("pending resize send failed: {any}\n", .{e});
-            };
-            self.pending_resize_valid = false;
-            self.log.write("pending resize sent rows={d} cols={d}\n", .{ pr2, pc2 });
-        }
-    }
-
-    if (self.stdout_file == null) {
-        self.log.write("stdout pipe is null\n", .{});
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return;
-    }
-
-    // Contiguous buffered reader. Replaces the byte-at-a-time PipeReader so
-    // the MessagePack decoder sees a `[]const u8` slice it can advance through.
-    // The buffer grows on demand when a single RPC frame exceeds the current
-    // capacity (e.g., a wide-grid `grid_line` carrying thousands of cells).
-    var fr = FrameReader.init(self.alloc, self.stdout_file.?) catch |e| {
-        self.log.write("FrameReader init failed: {any}\n", .{e});
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return;
-    };
-    defer fr.deinit();
-
-    var arena_state = std.heap.ArenaAllocator.init(self.alloc);
-    defer arena_state.deinit();
-
-    outer: while (!self.stop_flag.load(.seq_cst)) {
-        // Refill-on-EOF retry loop. The arena is reset between retries so
-        // that partial allocations from a failed decode don't accumulate.
-        //
-        // Note: an earlier iteration of this loop included a streaming
-        // fast path (probe + skipAny + `decodeFromStream`) for redraw
-        // notifications. Microbenchmarks (`zig build bench`) showed it
-        // was 1.24x–1.94x slower on the decode path alone — as long as
-        // handlers keep consuming `Value` trees, the streaming decoder
-        // loses both to the second scan pass and to the extra
-        // `ValueHead` dispatch layer. The fast path was removed; the
-        // streaming decoder (`src/core/mpack_stream.zig`) and its bridge
-        // helper (`msgpack.decodeFromStream`) are retained as reference
-        // implementations for any future rewrite that streams through
-        // the handlers directly (i.e., drops the intermediate `Value`
-        // tree on the `grid_line` hot path).
-        var root: mp.Value = undefined;
-        while (true) {
-            _ = arena_state.reset(.retain_capacity);
-            const arena_once = arena_state.allocator();
-
-            var sr = FrameSliceReader{ .data = fr.view() };
-            if (mp.decode(arena_once, &sr)) |v| {
-                fr.consume(sr.i);
-                root = v;
-                break;
-            } else |e| {
-                if (e == error.EndOfStream) {
-                    const n = fr.fill() catch |fe| {
-                        self.log.write("pipe read err: {any}\n", .{fe});
-                        break :outer;
-                    };
-                    if (n == 0) {
-                        self.log.write("decode err: EndOfStream (nvim stdout closed)\n", .{});
-                        break :outer;
-                    }
-                    continue;
-                }
-                self.log.write("decode err: {any}\n", .{e});
-                break :outer;
+        // If config.toml [font] family is set, push it to nvim's `guifont`
+        // BEFORE ui_attach (avoids a second paint round-trip; see original
+        // statusline-on-Windows note for context).
+        if (self.msg_config.font.family_explicit) {
+            var guifont_buf: [256]u8 = undefined;
+            const guifont_str = std.fmt.bufPrint(&guifont_buf, "{s}:h{d}", .{
+                self.msg_config.font.family,
+                self.msg_config.font.size,
+            }) catch null;
+            if (guifont_str) |val| {
+                self.requestSetOptionValue("guifont", val) catch |e|
+                    self.log.write("pre-attach set guifont failed: {any}\n", .{e});
             }
         }
 
-        const arena = arena_state.allocator();
-        if (root != .arr or root.arr.len < 1) continue;
-        const top = root.arr;
-        if (top[0] != .int) continue;
+        self.requestUiAttach(self.ui_attach_rows, self.ui_attach_cols) catch |e| {
+            self.log.write("ui_attach send failed: {any}\n", .{e});
+            teardownSpawnSession(self, &child, have_child);
+            break :session;
+        };
+        ui_attached = true;
+        ui_attached_overall = true;
+        self.ui_attached.store(true, .seq_cst);
+        self.flushPendingFocus();
 
-        const t = top[0].int;
-        if (t == 0) {
-            // RPC request from Neovim (e.g., clipboard operations)
-            handleRpcRequest(self, arena, top);
-            continue;
+        // Discover our channel_id via vim.api.nvim_list_chans() and install
+        // the clipboard provider hooks.
+        setupClipboard(self);
+
+        if (self.pending_resize_valid) {
+            const pr2 = self.pending_resize_rows;
+            const pc2 = self.pending_resize_cols;
+            if (pr2 == self.ui_attach_rows and pc2 == self.ui_attach_cols) {
+                self.pending_resize_valid = false;
+                self.log.write("pending resize skipped (same as attach size rows={d} cols={d})\n", .{ pr2, pc2 });
+            } else {
+                self.requestTryResize(pr2, pc2) catch |e| {
+                    self.log.write("pending resize send failed: {any}\n", .{e});
+                };
+                self.pending_resize_valid = false;
+                self.log.write("pending resize sent rows={d} cols={d}\n", .{ pr2, pc2 });
+            }
         }
-        if (t == 1) {
-            // RPC response (e.g., quit request result)
-            handleRpcResponse(self, top);
-            continue;
+
+        if (self.stdout_file == null) {
+            self.log.write("read transport is null\n", .{});
+            teardownSpawnSession(self, &child, have_child);
+            break :session;
         }
-        if (t == 2) {
-            handleRpcNotification(self, arena, top);
-            continue;
+
+        var fr = FrameReader.init(self.alloc, self.stdout_file.?) catch |e| {
+            self.log.write("FrameReader init failed: {any}\n", .{e});
+            teardownSpawnSession(self, &child, have_child);
+            break :session;
+        };
+        defer fr.deinit();
+
+        var arena_state = std.heap.ArenaAllocator.init(self.alloc);
+        defer arena_state.deinit();
+
+        // Inner reader loop — same for both transports. Earlier iterations
+        // experimented with a streaming fast path here; microbenchmarks
+        // showed the Value-tree path was 1.24x–1.94x faster, so the
+        // streaming machinery (mpack_stream / decodeFromStream) is kept
+        // only as a reference implementation.
+        outer: while (!self.stop_flag.load(.seq_cst)) {
+            var root: mp.Value = undefined;
+            while (true) {
+                _ = arena_state.reset(.retain_capacity);
+                const arena_once = arena_state.allocator();
+
+                var sr = FrameSliceReader{ .data = fr.view() };
+                if (mp.decode(arena_once, &sr)) |v| {
+                    fr.consume(sr.i);
+                    root = v;
+                    break;
+                } else |e| {
+                    if (e == error.EndOfStream) {
+                        const n = fr.fill() catch |fe| {
+                            self.log.write("pipe read err: {any}\n", .{fe});
+                            break :outer;
+                        };
+                        if (n == 0) {
+                            self.log.write("decode err: EndOfStream (nvim stdout closed)\n", .{});
+                            break :outer;
+                        }
+                        continue;
+                    }
+                    self.log.write("decode err: {any}\n", .{e});
+                    break :outer;
+                }
+            }
+
+            const arena = arena_state.allocator();
+            if (root != .arr or root.arr.len < 1) continue;
+            const top = root.arr;
+            if (top[0] != .int) continue;
+
+            const t = top[0].int;
+            if (t == 0) {
+                handleRpcRequest(self, arena, top);
+                continue;
+            }
+            if (t == 1) {
+                handleRpcResponse(self, top);
+                continue;
+            }
+            if (t == 2) {
+                handleRpcNotification(self, arena, top);
+                continue;
+            }
         }
+
+        // === Session cleanup ===
+        // Stop the writer thread before closing the transport so its
+        // in-flight writeAll() doesn't observe a torn-down handle.
+        var wt: ?std.Thread = null;
+        {
+            self.write_queue_mu.lock();
+            self.write_queue_closed = true;
+            wt = self.writer_thread;
+            self.writer_thread = null;
+            self.write_queue_cond.signal();
+            self.write_queue_mu.unlock();
+        }
+        // `:connect` hot-swap: the old nvim is still alive headless on
+        // its own listen socket and would block child.wait() forever
+        // (the process never exits). Don't kill, don't wait — just drop
+        // the handle. The orphan continues running until the user kills
+        // it manually. We still close OUR end of the pipes (just FDs in
+        // our process; doesn't affect the running nvim).
+        const orphan_child = self.connect_keeps_child_alive;
+
+        if (self.stdin_file) |f| {
+            f.close();
+            self.stdin_file = null;
+            // Socket transport aliases stdin and stdout on the same fd —
+            // closing once fully tears down the connection. Null both
+            // pointers so downstream cleanup does not double-close.
+            if (self.transport_kind == .socket) {
+                self.stdout_file = null;
+            }
+        }
+        if (wt) |t| t.join();
+
+        // Wait for the child (spawn mode only) and capture exit term.
+        var session_term: ?std.process.Child.Term = null;
+        if (have_child) {
+            if (orphan_child) {
+                self.log.write("orphaning headless nvim (pid={any}) for :connect hot-swap\n", .{child.id});
+                self.child_handle = null;
+            } else {
+                if (self.stop_flag.load(.seq_cst)) {
+                    _ = child.kill() catch {};
+                }
+                session_term = child.wait() catch |e| blk: {
+                    self.log.write("wait err: {any}\n", .{e});
+                    break :blk null;
+                };
+                if (session_term) |t| self.log.write("nvim terminated: {any}\n", .{t});
+                self.child_handle = null;
+            }
+        }
+        if (session_term) |t| last_term = t;
+
+        // Close any remaining transport handles.
+        if (self.stdout_file) |f| {
+            f.close();
+            self.stdout_file = null;
+        }
+        if (self.stderr_file) |f| {
+            f.close();
+            self.stderr_file = null;
+        }
+
+        // Join the stderr pump (if any). Closing stderr_file above causes
+        // its read() to return 0, exiting the thread cleanly.
+        if (self.stderr_thread) |t| {
+            t.join();
+            self.stderr_thread = null;
+        }
+
+        // === Decide next iteration ===
+        if (self.stop_flag.load(.seq_cst)) {
+            // App-side stop() observed; do not fire on_exit, do not loop.
+            return;
+        }
+
+        if (self.restart_pending_addr != null) {
+            // Restart/connect was queued during this session. Reset
+            // session-scoped state and loop back; the next iteration uses
+            // the connect path (or re-spawn fallback for remote modes).
+            // Consume the connect-keeps-alive flag now that the orphan
+            // (if any) has been dropped — the next session must not
+            // inherit it.
+            self.connect_keeps_child_alive = false;
+            self.resetSessionState();
+            if (self.stop_flag.load(.seq_cst)) return;
+            continue :session;
+        }
+
+        // Natural exit: nvim closed the channel without queueing a restart.
+        break :session;
     }
 
-    if (self.stop_flag.load(.seq_cst)) {
-        _ = child.kill() catch {};
-    }
-
-    const term = child.wait() catch |e| {
-        self.log.write("wait err: {any}\n", .{e});
-        return;
-    };
-    self.log.write("nvim terminated: {any}\n", .{term});
-    self.child_handle = null;
-
-
-    self.log.write("nvim terminated: {any}\n", .{term});
-    self.child_handle = null;
-
-    // If nvim exited by itself (e.g. :q), notify the frontend.
-    // When stop() is requested by the app side, stop_flag is set and we should not trigger on_exit.
-    if (!self.stop_flag.load(.seq_cst) and ui_attached) {
+    // === After-loop: fire on_exit ===
+    // Suppressed only when stop() was already invoked (user-driven shutdown:
+    // window close, app quit). For all other paths — including pre-attach
+    // failures like connect-only socket-not-found, spawn failure, ui_attach
+    // send failure, FrameReader init failure — we still fire on_exit so the
+    // frontend can tear down its window instead of leaving a blank shell.
+    if (!self.stop_flag.load(.seq_cst)) {
         if (self.cb.on_exit) |f| {
             // Convert Term to exit code:
-            // - Exited: use exit code directly
-            // - Signal: 128 + signal number (Unix convention)
-            // - Stopped/Unknown: return 1 (generic error)
-            const exit_code: i32 = switch (term) {
+            //   - Exited: use exit code directly
+            //   - Signal: 128 + signal number (Unix convention)
+            //   - Stopped/Unknown: return 1 (generic error)
+            //   - Natural exit in connect mode (no Term, ui attached): 0
+            //   - Pre-attach failure (no Term, never attached): 1
+            const exit_code: i32 = if (last_term) |t| switch (t) {
                 .Exited => |code| @intCast(code),
                 .Signal => |sig| 128 + @as(i32, @intCast(sig)),
                 .Stopped, .Unknown => 1,
-            };
+            } else if (ui_attached_overall) 0 else 1;
             self.log.write("calling on_exit with code: {d}\n", .{exit_code});
             f(self.ctx, exit_code);
         }
+    }
+}
+
+/// Tear down a partially-set-up spawn session without firing on_exit.
+/// Called from early-exit paths inside runLoop (ui_attach failure, stop
+/// during ssh-auth wait, etc.). Safe to call when have_child is false.
+fn teardownSpawnSession(self: *Core, child: *std.process.Child, have_child: bool) void {
+    if (have_child) {
+        _ = child.kill() catch {};
+        _ = child.wait() catch {};
+        self.child_handle = null;
     }
 }

--- a/src/core/rpc_transport.zig
+++ b/src/core/rpc_transport.zig
@@ -85,6 +85,53 @@ pub const Stream = union(enum) {
         }
     }
 
+    /// Wake any blocked read/writeAll on this stream so the holding
+    /// thread can return promptly. Must be called BEFORE close().
+    /// Used at session teardown when the reader/writer threads sit on
+    /// a socket fd that another thread is about to close.
+    ///
+    /// Why this is needed (POSIX socket only):
+    ///   For connect-mode (.socket transport) stdin and stdout alias
+    ///   the same fd. Closing it from another thread does NOT
+    ///   reliably wake threads already blocked in read()/write() on
+    ///   the same fd — the kernel keeps an in-flight reference for
+    ///   each blocked syscall, and only completes them when the peer
+    ///   shuts down its side. shutdown(SHUT_RDWR) makes the kernel
+    ///   immediately deliver EOF to readers and EPIPE to writers on
+    ///   our side, regardless of peer state.
+    ///
+    /// Pipe transport (.file with pipe fds): not needed. stdin and
+    /// stdout are separate fds, and closing stdin causes nvim to
+    /// exit, which closes stdout from its side → reader gets EOF
+    /// naturally.
+    ///
+    /// Windows .win_pipe: not needed. closeHandles() already fires
+    /// CancelIoEx on the pipe HANDLE, which releases blocked
+    /// GetOverlappedResult calls.
+    ///
+    /// `is_socket` MUST be accurate: posix.shutdown panics on a
+    /// non-socket fd (NOTSOCK is `unreachable` in the Zig wrapper).
+    /// Errors are swallowed — at teardown we only care that the
+    /// blocked thread is woken; a SocketNotConnected or
+    /// ConnectionResetByPeer is acceptable noise.
+    pub fn shutdownIfSocket(self: Stream, is_socket: bool) void {
+        if (!is_socket) return;
+        // Windows `.file` is only used for spawn-mode pipe transport in
+        // this codebase — connect-mode socket equivalent is `.win_pipe`
+        // (named pipe), whose closeHandles() already fires CancelIoEx
+        // to release blocked GetOverlappedResult calls. Skip the
+        // POSIX shutdown branch on Windows: std.fs.File.handle is
+        // windows.HANDLE while std.posix.shutdown expects
+        // ws2_32.SOCKET, so the call would not even compile.
+        if (builtin.os.tag == .windows) return;
+        switch (self) {
+            .file => |f| {
+                std.posix.shutdown(f.handle, .both) catch {};
+            },
+            .win_pipe => {},
+        }
+    }
+
     pub fn fromFile(f: std.fs.File) Stream {
         return .{ .file = f };
     }

--- a/src/core/rpc_transport.zig
+++ b/src/core/rpc_transport.zig
@@ -65,10 +65,23 @@ pub const Stream = union(enum) {
         };
     }
 
+    /// Cancel pending I/O on the underlying transport so any blocked
+    /// read/write returns. Semantics differ by backend:
+    ///   - `.file`: closes the fd/HANDLE outright. Self-contained.
+    ///   - `.win_pipe`: calls `WindowsOverlappedPipe.closeHandles()`
+    ///     which fires `CancelIoEx` only — neither the pipe HANDLE
+    ///     nor the event HANDLEs are closed here, because other
+    ///     threads holding a Stream value may still be sleeping in
+    ///     `GetOverlappedResult(self.handle, ovl, ..., TRUE)` and
+    ///     closing those HANDLEs mid-wait is undefined behavior.
+    ///     Both the HANDLEs and the wrapper memory are released
+    ///     later via `WindowsOverlappedPipe.destroy()`, which the
+    ///     owner must call exactly once after every such thread has
+    ///     been joined.
     pub fn close(self: Stream) void {
         switch (self) {
             .file => |f| f.close(),
-            .win_pipe => |p| p.deinit(),
+            .win_pipe => |p| p.closeHandles(),
         }
     }
 
@@ -86,12 +99,44 @@ pub const WindowsOverlappedPipe = if (builtin.os.tag == .windows) struct {
     handle: windows.HANDLE,
     read_event: windows.HANDLE,
     write_event: windows.HANDLE,
+    /// Atomic shutdown flag observed by read()/writeAll() at the top
+    /// of every loop iteration AND re-checked after a WriteFile/
+    /// ReadFile returns IO_PENDING. Set exactly once via swap() in
+    /// closeHandles(). Atomic (not plain bool) because closeHandles()
+    /// runs on the UI / RPC thread while read()/writeAll() run on the
+    /// reader / writer thread; without acquire-release synchronization
+    /// the writer could miss the cancellation, issue a fresh WriteFile
+    /// after CancelIoEx fired (which only catches I/O outstanding at
+    /// the time of the call), and then hang in GetOverlappedResult.
+    handles_closed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     alloc: std.mem.Allocator,
 
     /// Open a Windows named pipe with FILE_FLAG_OVERLAPPED and set up
     /// auto-reset completion events for read and write. Returns a heap-
-    /// allocated wrapper; the caller is responsible for calling
-    /// `deinit()` exactly once at session teardown.
+    /// allocated wrapper.
+    ///
+    /// Lifetime contract: the wrapper has TWO teardown phases the
+    /// owner must run in order:
+    ///   1. `closeHandles()` (idempotent) — calls `CancelIoEx` on the
+    ///      pipe HANDLE, which marks all currently-pending overlapped
+    ///      I/O on that handle as aborted; the kernel writes
+    ///      STATUS_CANCELLED into OVERLAPPED.Internal and signals
+    ///      OVERLAPPED.hEvent. Any thread sleeping in
+    ///      `GetOverlappedResult(self.handle, ovl, ..., TRUE)` wakes
+    ///      up and returns FALSE with ERROR_OPERATION_ABORTED. We do
+    ///      NOT call `CloseHandle(self.handle)` here, because closing
+    ///      the file HANDLE while another thread still holds it as
+    ///      the first argument to GetOverlappedResult is undefined
+    ///      behavior per MSDN. Event HANDLEs are also left alive for
+    ///      the same reason. Do NOT free the wrapper here.
+    ///   2. `destroy()` — closes the pipe HANDLE, the event HANDLEs,
+    ///      and frees the wrapper struct. MUST be called exactly once,
+    ///      AFTER every thread that received a copy of the Stream
+    ///      value (writer, reader, stderr pump) has been joined;
+    ///      otherwise the close races with their in-flight use of
+    ///      self.handle / read_event / write_event.
+    /// Skipping phase 1 is safe (destroy() closes the handle anyway)
+    /// but loses the ability to unblock blocked I/O before joining.
     pub fn open(alloc: std.mem.Allocator, addr: []const u8) ConnectError!*WindowsOverlappedPipe {
         const path_w = std.unicode.utf8ToUtf16LeAllocZ(alloc, addr) catch return error.OutOfMemory;
         defer alloc.free(path_w);
@@ -134,7 +179,52 @@ pub const WindowsOverlappedPipe = if (builtin.os.tag == .windows) struct {
         return self;
     }
 
-    pub fn deinit(self: *WindowsOverlappedPipe) void {
+    /// Phase 1 of teardown: cancel pending overlapped I/O without
+    /// closing any HANDLE. `CancelIoEx(self.handle, NULL)` marks every
+    /// outstanding I/O on the pipe as aborted; the kernel updates
+    /// OVERLAPPED.Internal to STATUS_CANCELLED and signals the
+    /// associated event. A thread blocked in
+    /// `GetOverlappedResult(self.handle, ovl, ..., TRUE)` wakes up
+    /// and returns FALSE with ERROR_OPERATION_ABORTED, which `read()`
+    /// / `writeAll()` translate to EOF / OperationAborted.
+    ///
+    /// IMPORTANT: self.handle, read_event, and write_event are all
+    /// left alive here. MSDN's contract is that closing a HANDLE while
+    /// another thread is still using it (as the file handle for
+    /// GetOverlappedResult, or as the wait HANDLE for an overlapped
+    /// completion event) is undefined behavior. They are closed in
+    /// destroy() after the caller has joined every thread that could
+    /// hold a reference. Idempotent — safe to call multiple times
+    /// (e.g. from the alias close in socket mode).
+    ///
+    /// Race coverage: CancelIoEx only cancels I/O outstanding at the
+    /// time of the call. To stop the writer from issuing a *fresh*
+    /// WriteFile after CancelIoEx fires (which would then hang in
+    /// GetOverlappedResult), the atomic flag is set BEFORE CancelIoEx
+    /// runs (release ordering pairs with the acquire load at the top
+    /// of writeAll/read iterations); writeAll/read also re-check the
+    /// flag after a successful WriteFile/ReadFile returns IO_PENDING
+    /// and call CancelIoEx targeted at the specific OVERLAPPED so
+    /// that fresh I/O is also canceled. See read()/writeAll().
+    pub fn closeHandles(self: *WindowsOverlappedPipe) void {
+        // swap returns the previous value; if it was already true,
+        // closeHandles already ran (e.g. via the alias close in socket
+        // mode) and CancelIoEx has nothing new to do.
+        if (self.handles_closed.swap(true, .acq_rel)) return;
+        _ = windows.kernel32.CancelIoEx(self.handle, null);
+    }
+
+    /// Phase 2 of teardown: close the pipe HANDLE, the completion
+    /// events, and free the heap allocation. MUST be called exactly
+    /// once and only after every thread that holds a
+    /// `*WindowsOverlappedPipe` (writer thread, reader, stderr pump,
+    /// etc.) has been joined — otherwise closing self.handle /
+    /// read_event / write_event mid-use is undefined behavior, and
+    /// the alloc.destroy() races with the threads' dereferences.
+    /// Calls closeHandles() first as a safety net (no-op if already
+    /// canceled by Stream.close()).
+    pub fn destroy(self: *WindowsOverlappedPipe) void {
+        self.closeHandles();
         windows.CloseHandle(self.handle);
         windows.CloseHandle(self.read_event);
         windows.CloseHandle(self.write_event);
@@ -157,10 +247,16 @@ pub const WindowsOverlappedPipe = if (builtin.os.tag == .windows) struct {
         return bytes;
     }
 
-    /// Blocking read. Returns 0 on EOF (broken pipe). Uses overlapped
-    /// I/O so a concurrent writeAll() on the same handle doesn't block.
+    /// Blocking read. Returns 0 on EOF (broken pipe or shutdown
+    /// observed). Uses overlapped I/O so a concurrent writeAll() on
+    /// the same handle doesn't block.
     pub fn read(self: *WindowsOverlappedPipe, buf: []u8) !usize {
         if (buf.len == 0) return 0;
+        // Pre-check shutdown (acquire pairs with the release in
+        // closeHandles' swap). If shutdown was observed, return EOF
+        // without issuing a fresh ReadFile that the prior CancelIoEx
+        // would not catch.
+        if (self.handles_closed.load(.acquire)) return 0;
 
         var overlapped: windows.OVERLAPPED = std.mem.zeroes(windows.OVERLAPPED);
         overlapped.hEvent = self.read_event;
@@ -171,7 +267,18 @@ pub const WindowsOverlappedPipe = if (builtin.os.tag == .windows) struct {
         const ok = windows.kernel32.ReadFile(self.handle, buf.ptr, want, &bytes_read, &overlapped);
         if (ok == 0) {
             switch (windows.kernel32.GetLastError()) {
-                .IO_PENDING => {}, // proceed to GetOverlappedResult below
+                .IO_PENDING => {
+                    // Race recovery: closeHandles may have fired between
+                    // our pre-check and ReadFile. The prior CancelIoEx
+                    // (with NULL OVERLAPPED) only catches I/O outstanding
+                    // at its call instant, so this fresh ReadFile would
+                    // otherwise hang in GetOverlappedResult. Re-check the
+                    // flag and cancel this specific OVERLAPPED if so;
+                    // GetOverlappedResult will then return ABORTED quickly.
+                    if (self.handles_closed.load(.acquire)) {
+                        _ = windows.kernel32.CancelIoEx(self.handle, &overlapped);
+                    }
+                },
                 .BROKEN_PIPE, .HANDLE_EOF => return 0,
                 .OPERATION_ABORTED => return error.OperationAborted,
                 .NETNAME_DELETED => return error.ConnectionResetByPeer,
@@ -186,10 +293,18 @@ pub const WindowsOverlappedPipe = if (builtin.os.tag == .windows) struct {
     }
 
     /// Blocking writeAll. Loops on partial writes (rare for pipes but
-    /// possible for very large buffers).
+    /// possible for very large buffers). Per-iteration shutdown check
+    /// + post-IO_PENDING re-check + targeted CancelIoEx eliminate the
+    /// race where stop() fires CancelIoEx between writer's queue-pop
+    /// and WriteFile call (the prior CancelIoEx wouldn't catch the
+    /// fresh I/O, leaving the writer hung in GetOverlappedResult).
     pub fn writeAll(self: *WindowsOverlappedPipe, bytes: []const u8) !void {
         var idx: usize = 0;
         while (idx < bytes.len) {
+            // Per-iteration pre-check (acquire pairs with the release
+            // in closeHandles' swap).
+            if (self.handles_closed.load(.acquire)) return error.OperationAborted;
+
             var overlapped: windows.OVERLAPPED = std.mem.zeroes(windows.OVERLAPPED);
             overlapped.hEvent = self.write_event;
 
@@ -199,7 +314,19 @@ pub const WindowsOverlappedPipe = if (builtin.os.tag == .windows) struct {
             const ok = windows.kernel32.WriteFile(self.handle, bytes.ptr + idx, want, &bytes_written, &overlapped);
             if (ok == 0) {
                 switch (windows.kernel32.GetLastError()) {
-                    .IO_PENDING => {}, // proceed to GetOverlappedResult below
+                    .IO_PENDING => {
+                        // Race recovery: closeHandles may have fired
+                        // between our pre-check and WriteFile. The prior
+                        // CancelIoEx (NULL OVERLAPPED) only catches I/O
+                        // outstanding at the call instant, so this fresh
+                        // WriteFile would otherwise hang in
+                        // GetOverlappedResult. Cancel this specific
+                        // OVERLAPPED so GetOverlappedResult returns
+                        // ABORTED quickly.
+                        if (self.handles_closed.load(.acquire)) {
+                            _ = windows.kernel32.CancelIoEx(self.handle, &overlapped);
+                        }
+                    },
                     .BROKEN_PIPE => return error.BrokenPipe,
                     .OPERATION_ABORTED => return error.OperationAborted,
                     .NETNAME_DELETED => return error.ConnectionResetByPeer,
@@ -221,7 +348,10 @@ pub const WindowsOverlappedPipe = if (builtin.os.tag == .windows) struct {
     pub fn open(_: std.mem.Allocator, _: []const u8) ConnectError!*@This() {
         unreachable;
     }
-    pub fn deinit(_: *@This()) void {
+    pub fn closeHandles(_: *@This()) void {
+        unreachable;
+    }
+    pub fn destroy(_: *@This()) void {
         unreachable;
     }
     pub fn read(_: *@This(), _: []u8) !usize {
@@ -238,7 +368,10 @@ pub const WindowsOverlappedPipe = if (builtin.os.tag == .windows) struct {
 ///   - "host:port"        (TCP) — first character is digit, '[' (IPv6
 ///                                bracket), or alphanumeric followed by
 ///                                ':' and digits.
-///   - "/abs/path"        (Unix domain socket) — starts with '/' or '~'.
+///   - "/abs/path"        (Unix domain socket) — absolute path starting
+///                                with '/'. No '~' expansion is performed,
+///                                so home-relative paths must be expanded
+///                                by the caller before being passed in.
 ///   - "\\.\pipe\..."     (Windows named pipe) — also accepts "\\?\pipe\".
 pub const Parsed = union(enum) {
     tcp: struct { host: []const u8, port: u16 },
@@ -270,8 +403,12 @@ pub fn parseListenAddr(addr: []const u8) ?Parsed {
         return .{ .pipe = addr };
     }
 
-    // Unix domain socket: absolute path or home-relative.
-    if (addr[0] == '/' or addr[0] == '~') {
+    // Unix domain socket: absolute path only. `~` home-relative paths are
+    // intentionally rejected — the C ABI promises `fail fast` on invalid
+    // addresses, but nothing on the connect path expands `~` (it would be
+    // passed verbatim to connectUnixSocket and fail at runtime). Users
+    // should pass an absolute path, e.g. `/Users/me/.cache/nvim/nvim.sock`.
+    if (addr[0] == '/') {
         return .{ .unix = addr };
     }
 
@@ -299,6 +436,23 @@ pub fn parseListenAddr(addr: []const u8) ?Parsed {
     const port = std.fmt.parseInt(u16, port_str, 10) catch return null;
     if (host.len == 0) return null;
     return .{ .tcp = .{ .host = host, .port = port } };
+}
+
+/// Returns true if `addr` is a well-formed listen address that
+/// `connectListenAddr` would accept on the current platform. Used by
+/// the C ABI (`zonvie_core_start_connect`) to fail fast with a parse
+/// error before spawning the run-loop thread, instead of letting the
+/// failure surface asynchronously through `on_exit`.
+///
+/// Platform support matrix:
+///     POSIX (macOS, Linux): TCP, Unix socket
+///     Windows:              named pipe
+pub fn isAddrSupported(addr: []const u8) bool {
+    const parsed = parseListenAddr(addr) orelse return false;
+    return switch (parsed) {
+        .tcp, .unix => builtin.os.tag != .windows,
+        .pipe => builtin.os.tag == .windows,
+    };
 }
 
 /// Connect to a Neovim listen address and return a `Stream`. The
@@ -388,4 +542,35 @@ test "parseListenAddr: rejects unbracketed ipv6" {
 
 test "parseListenAddr: rejects non-pipe UNC path" {
     try std.testing.expect(parseListenAddr("\\\\server\\share") == null);
+}
+
+test "parseListenAddr: rejects ~ home-relative path (no expansion)" {
+    // The connect path passes the address verbatim to connectUnixSocket,
+    // which does not expand `~`. Accepting it here would let
+    // zonvie_core_start_connect return 0 and fail asynchronously, breaking
+    // the `fail fast` ABI contract. Force absolute paths instead.
+    try std.testing.expect(parseListenAddr("~/nvim.sock") == null);
+    try std.testing.expect(parseListenAddr("~root/nvim.sock") == null);
+}
+
+test "isAddrSupported: rejects malformed input on every platform" {
+    try std.testing.expect(!isAddrSupported(""));
+    try std.testing.expect(!isAddrSupported("localhost"));
+    try std.testing.expect(!isAddrSupported(":1234"));
+    try std.testing.expect(!isAddrSupported("\\\\server\\share"));
+}
+
+test "isAddrSupported: platform-specific acceptance matrix" {
+    if (builtin.os.tag == .windows) {
+        // Windows: only named pipes are supported today.
+        try std.testing.expect(isAddrSupported("\\\\.\\pipe\\nvim.31920.0"));
+        try std.testing.expect(!isAddrSupported("127.0.0.1:6789"));
+        try std.testing.expect(!isAddrSupported("/tmp/nvim.42.0"));
+    } else {
+        // POSIX: TCP and Unix sockets supported; pipes are not.
+        try std.testing.expect(isAddrSupported("127.0.0.1:6789"));
+        try std.testing.expect(isAddrSupported("[::1]:6789"));
+        try std.testing.expect(isAddrSupported("/tmp/nvim.42.0"));
+        try std.testing.expect(!isAddrSupported("\\\\.\\pipe\\nvim.31920.0"));
+    }
 }

--- a/src/core/rpc_transport.zig
+++ b/src/core/rpc_transport.zig
@@ -1,0 +1,208 @@
+// rpc_transport.zig — RPC transport layer for nvim sessions.
+//
+// Two transports are supported:
+//   - Spawn: a child nvim process attached over 3 pipes (stdin/stdout/stderr).
+//     This is the default and what `runSpawnOnce` uses.
+//   - Socket: a TCP, Unix-domain-socket, or Windows named-pipe connection
+//     to an already-running nvim server. Used for `:restart` and the
+//     "connect to running nvim" feature. The connected fd/HANDLE serves
+//     both read and write, and is wrapped in a `std.fs.File` so the
+//     existing `FrameReader` and `writerThreadFn` (which both operate on
+//     `std.fs.File`) can be reused unchanged.
+//
+// Platform notes:
+//   - POSIX: TCP and Unix-domain sockets work via std.net (same posix.fd_t
+//     as a regular file, so the alias trick is transparent).
+//   - Windows: NEITHER TCP NOR named-pipe connect is supported yet.
+//     - TCP: winsock SOCKET is not interchangeable with a HANDLE for
+//       ReadFile/WriteFile.
+//     - Named pipe: synchronous-mode HANDLEs serialize ReadFile/WriteFile
+//       at the kernel level, so when FrameReader is blocked in ReadFile
+//       waiting for nvim output, the writer thread's WriteFile deadlocks
+//       indefinitely. Real fix requires opening the pipe with
+//       FILE_FLAG_OVERLAPPED and rewriting the I/O paths around OVERLAPPED
+//       structures (libuv's approach). Tracked as TODO; the parser still
+//       recognizes pipe paths so the future implementation has a clean
+//       hook point. Until then, callers fall back to re-spawning nvim.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const ConnectError = error{
+    InvalidAddress,
+    UnsupportedOnWindows,
+    UnsupportedOnPosix,
+    ConnectionRefused,
+} || std.net.TcpConnectToHostError ||
+    std.net.TcpConnectToAddressError ||
+    std.posix.SocketError ||
+    std.posix.ConnectError ||
+    std.mem.Allocator.Error;
+
+/// A connected RPC transport. The `file` field aliases the socket fd
+/// (POSIX) or pipe HANDLE (Windows); reading and writing both operate
+/// on the same handle, so closing the file once is sufficient — never
+/// close it twice.
+pub const Connection = struct {
+    file: std.fs.File,
+
+    pub fn close(self: *Connection) void {
+        self.file.close();
+    }
+};
+
+/// Parse a Neovim listen address into one of the three supported forms.
+///
+/// Forms recognized:
+///   - "host:port"        (TCP) — first character is digit, '[' (IPv6
+///                                bracket), or alphanumeric followed by
+///                                ':' and digits.
+///   - "/abs/path"        (Unix domain socket) — starts with '/' or '~'.
+///   - "\\.\pipe\..."     (Windows named pipe) — also accepts "\\?\pipe\".
+pub const Parsed = union(enum) {
+    tcp: struct { host: []const u8, port: u16 },
+    unix: []const u8,
+    pipe: []const u8,
+};
+
+fn isPipePath(addr: []const u8) bool {
+    // \\.\pipe\... or \\?\pipe\...
+    if (addr.len < 9) return false;
+    if (addr[0] != '\\' or addr[1] != '\\') return false;
+    if (addr[2] != '.' and addr[2] != '?') return false;
+    if (addr[3] != '\\') return false;
+    const tail = addr[4..];
+    if (tail.len < 5) return false;
+    // Match "pipe\" case-insensitively.
+    if (std.ascii.toLower(tail[0]) != 'p') return false;
+    if (std.ascii.toLower(tail[1]) != 'i') return false;
+    if (std.ascii.toLower(tail[2]) != 'p') return false;
+    if (std.ascii.toLower(tail[3]) != 'e') return false;
+    if (tail[4] != '\\') return false;
+    return true;
+}
+
+pub fn parseListenAddr(addr: []const u8) ?Parsed {
+    if (addr.len == 0) return null;
+
+    // Windows named pipe: \\.\pipe\... or \\?\pipe\...
+    if (isPipePath(addr)) {
+        return .{ .pipe = addr };
+    }
+
+    // Unix domain socket: absolute path or home-relative.
+    if (addr[0] == '/' or addr[0] == '~') {
+        return .{ .unix = addr };
+    }
+
+    // Other "\\..." UNC paths (not pipes) — ambiguous; reject.
+    if (addr.len >= 2 and addr[0] == '\\' and addr[1] == '\\') return null;
+
+    // TCP host:port. Find the LAST ':' so IPv6 addresses ("::1:port") parse
+    // correctly when bracketed ("[::1]:port"); for the unbracketed case we
+    // intentionally treat them as ambiguous and return null.
+    if (addr[0] == '[') {
+        // IPv6 bracketed form: "[host]:port"
+        const close_bracket = std.mem.lastIndexOfScalar(u8, addr, ']') orelse return null;
+        if (close_bracket + 1 >= addr.len or addr[close_bracket + 1] != ':') return null;
+        const host = addr[1..close_bracket];
+        const port_str = addr[close_bracket + 2 ..];
+        const port = std.fmt.parseInt(u16, port_str, 10) catch return null;
+        return .{ .tcp = .{ .host = host, .port = port } };
+    }
+
+    const colon = std.mem.lastIndexOfScalar(u8, addr, ':') orelse return null;
+    // If there are multiple ':' (IPv6 unbracketed), treat as ambiguous.
+    if (std.mem.indexOfScalar(u8, addr[0..colon], ':') != null) return null;
+    const host = addr[0..colon];
+    const port_str = addr[colon + 1 ..];
+    const port = std.fmt.parseInt(u16, port_str, 10) catch return null;
+    if (host.len == 0) return null;
+    return .{ .tcp = .{ .host = host, .port = port } };
+}
+
+/// Connect to a Neovim listen address and return a `Connection`. The
+/// connection's underlying fd is used for both read and write, and is
+/// closed exactly once at session teardown.
+///
+/// Windows: returns `error.UnsupportedOnWindows` for all forms today (see
+/// file header for the named-pipe deadlock rationale). The caller's
+/// re-spawn fallback handles `:restart` in degraded mode.
+pub fn connectListenAddr(alloc: std.mem.Allocator, addr: []const u8) ConnectError!Connection {
+    if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
+
+    const parsed = parseListenAddr(addr) orelse return error.InvalidAddress;
+
+    const stream = switch (parsed) {
+        .tcp => |t| try std.net.tcpConnectToHost(alloc, t.host, t.port),
+        .unix => |p| try std.net.connectUnixSocket(p),
+        // Pipe paths are Windows-only; the early return above already
+        // handled them for that platform.
+        .pipe => return error.UnsupportedOnPosix,
+    };
+
+    // Alias the socket fd as a std.fs.File. On POSIX both expose the same
+    // posix.fd_t, and posix.read/write/close work uniformly on socket fds.
+    return .{ .file = std.fs.File{ .handle = stream.handle } };
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+test "parseListenAddr: unix socket path" {
+    const r = parseListenAddr("/tmp/nvim.42.0") orelse unreachable;
+    try std.testing.expect(r == .unix);
+    try std.testing.expectEqualStrings("/tmp/nvim.42.0", r.unix);
+}
+
+test "parseListenAddr: tcp ipv4" {
+    const r = parseListenAddr("127.0.0.1:6789") orelse unreachable;
+    try std.testing.expect(r == .tcp);
+    try std.testing.expectEqualStrings("127.0.0.1", r.tcp.host);
+    try std.testing.expectEqual(@as(u16, 6789), r.tcp.port);
+}
+
+test "parseListenAddr: tcp ipv6 bracketed" {
+    const r = parseListenAddr("[::1]:6789") orelse unreachable;
+    try std.testing.expect(r == .tcp);
+    try std.testing.expectEqualStrings("::1", r.tcp.host);
+    try std.testing.expectEqual(@as(u16, 6789), r.tcp.port);
+}
+
+test "parseListenAddr: windows named pipe (\\\\.\\)" {
+    const r = parseListenAddr("\\\\.\\pipe\\nvim.31920.0") orelse unreachable;
+    try std.testing.expect(r == .pipe);
+    try std.testing.expectEqualStrings("\\\\.\\pipe\\nvim.31920.0", r.pipe);
+}
+
+test "parseListenAddr: windows named pipe (\\\\?\\)" {
+    const r = parseListenAddr("\\\\?\\pipe\\nvim") orelse unreachable;
+    try std.testing.expect(r == .pipe);
+}
+
+test "parseListenAddr: windows named pipe case-insensitive" {
+    const r = parseListenAddr("\\\\.\\PIPE\\nvim") orelse unreachable;
+    try std.testing.expect(r == .pipe);
+}
+
+test "parseListenAddr: rejects empty" {
+    try std.testing.expect(parseListenAddr("") == null);
+}
+
+test "parseListenAddr: rejects bare hostname" {
+    try std.testing.expect(parseListenAddr("localhost") == null);
+}
+
+test "parseListenAddr: rejects bare port" {
+    try std.testing.expect(parseListenAddr(":1234") == null);
+}
+
+test "parseListenAddr: rejects unbracketed ipv6" {
+    // Ambiguous: ::1:6789 has multiple colons and no brackets.
+    try std.testing.expect(parseListenAddr("::1:6789") == null);
+}
+
+test "parseListenAddr: rejects non-pipe UNC path" {
+    try std.testing.expect(parseListenAddr("\\\\server\\share") == null);
+}

--- a/src/core/rpc_transport.zig
+++ b/src/core/rpc_transport.zig
@@ -6,24 +6,25 @@
 //   - Socket: a TCP, Unix-domain-socket, or Windows named-pipe connection
 //     to an already-running nvim server. Used for `:restart` and the
 //     "connect to running nvim" feature. The connected fd/HANDLE serves
-//     both read and write, and is wrapped in a `std.fs.File` so the
-//     existing `FrameReader` and `writerThreadFn` (which both operate on
-//     `std.fs.File`) can be reused unchanged.
+//     both read and write.
 //
-// Platform notes:
-//   - POSIX: TCP and Unix-domain sockets work via std.net (same posix.fd_t
-//     as a regular file, so the alias trick is transparent).
-//   - Windows: NEITHER TCP NOR named-pipe connect is supported yet.
-//     - TCP: winsock SOCKET is not interchangeable with a HANDLE for
-//       ReadFile/WriteFile.
-//     - Named pipe: synchronous-mode HANDLEs serialize ReadFile/WriteFile
-//       at the kernel level, so when FrameReader is blocked in ReadFile
-//       waiting for nvim output, the writer thread's WriteFile deadlocks
-//       indefinitely. Real fix requires opening the pipe with
-//       FILE_FLAG_OVERLAPPED and rewriting the I/O paths around OVERLAPPED
-//       structures (libuv's approach). Tracked as TODO; the parser still
-//       recognizes pipe paths so the future implementation has a clean
-//       hook point. Until then, callers fall back to re-spawning nvim.
+// All callers operate on a `Stream` wrapper so the read/write paths look
+// identical regardless of backend:
+//   - On POSIX, `Stream.file` is a `std.fs.File` aliasing the socket fd
+//     (or the child pipe). `read`/`writeAll`/`close` go straight through.
+//   - On Windows for spawn-mode child pipes, `Stream.file` works the same
+//     way (separate handles for stdin/stdout/stderr; each I/O path uses
+//     its own handle, so the kernel's per-handle synchronization never
+//     contends).
+//   - On Windows for named-pipe connect, the pipe is opened with
+//     FILE_FLAG_OVERLAPPED and wrapped as a `*WindowsOverlappedPipe`.
+//     Sync-mode HANDLEs would serialize ReadFile/WriteFile at the kernel
+//     level — when FrameReader is blocked in ReadFile waiting for nvim
+//     output, the writer thread's WriteFile would deadlock — so the
+//     overlapped path uses `OVERLAPPED` + `GetOverlappedResult` to let
+//     read and write proceed independently. The wrapper exposes
+//     synchronous-blocking semantics so the existing FrameReader and
+//     writerThreadFn don't need to know about overlapped I/O.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -33,21 +34,201 @@ pub const ConnectError = error{
     UnsupportedOnWindows,
     UnsupportedOnPosix,
     ConnectionRefused,
+    PipeBusy,
+    PipeOpenFailed,
+    EventCreateFailed,
 } || std.net.TcpConnectToHostError ||
     std.net.TcpConnectToAddressError ||
     std.posix.SocketError ||
     std.posix.ConnectError ||
     std.mem.Allocator.Error;
 
-/// A connected RPC transport. The `file` field aliases the socket fd
-/// (POSIX) or pipe HANDLE (Windows); reading and writing both operate
-/// on the same handle, so closing the file once is sufficient — never
-/// close it twice.
-pub const Connection = struct {
+/// Synchronous-blocking I/O abstraction over either a regular file/socket
+/// (`std.fs.File`) or a Windows overlapped named pipe. The abstraction
+/// hides overlapped-I/O bookkeeping so FrameReader / writerThreadFn / the
+/// stderr pump can treat any backend uniformly.
+pub const Stream = union(enum) {
     file: std.fs.File,
+    win_pipe: *WindowsOverlappedPipe,
 
-    pub fn close(self: *Connection) void {
-        self.file.close();
+    pub fn read(self: Stream, buf: []u8) !usize {
+        return switch (self) {
+            .file => |f| f.read(buf),
+            .win_pipe => |p| p.read(buf),
+        };
+    }
+
+    pub fn writeAll(self: Stream, bytes: []const u8) !void {
+        return switch (self) {
+            .file => |f| f.writeAll(bytes),
+            .win_pipe => |p| p.writeAll(bytes),
+        };
+    }
+
+    pub fn close(self: Stream) void {
+        switch (self) {
+            .file => |f| f.close(),
+            .win_pipe => |p| p.deinit(),
+        }
+    }
+
+    pub fn fromFile(f: std.fs.File) Stream {
+        return .{ .file = f };
+    }
+};
+
+/// Opaque-on-POSIX struct with a stub interface that panics if the
+/// non-Windows code paths somehow hit it. On Windows it's a full wrapper
+/// around an overlapped HANDLE plus per-direction completion events.
+pub const WindowsOverlappedPipe = if (builtin.os.tag == .windows) struct {
+    const windows = std.os.windows;
+
+    handle: windows.HANDLE,
+    read_event: windows.HANDLE,
+    write_event: windows.HANDLE,
+    alloc: std.mem.Allocator,
+
+    /// Open a Windows named pipe with FILE_FLAG_OVERLAPPED and set up
+    /// auto-reset completion events for read and write. Returns a heap-
+    /// allocated wrapper; the caller is responsible for calling
+    /// `deinit()` exactly once at session teardown.
+    pub fn open(alloc: std.mem.Allocator, addr: []const u8) ConnectError!*WindowsOverlappedPipe {
+        const path_w = std.unicode.utf8ToUtf16LeAllocZ(alloc, addr) catch return error.OutOfMemory;
+        defer alloc.free(path_w);
+
+        const handle = windows.kernel32.CreateFileW(
+            path_w.ptr,
+            windows.GENERIC_READ | windows.GENERIC_WRITE,
+            0, // no sharing
+            null, // default security
+            windows.OPEN_EXISTING,
+            windows.FILE_FLAG_OVERLAPPED,
+            null,
+        );
+
+        if (handle == windows.INVALID_HANDLE_VALUE) {
+            return switch (windows.kernel32.GetLastError()) {
+                .FILE_NOT_FOUND, .PATH_NOT_FOUND => error.ConnectionRefused,
+                .PIPE_BUSY => error.PipeBusy,
+                else => error.PipeOpenFailed,
+            };
+        }
+        errdefer windows.CloseHandle(handle);
+
+        // Auto-reset events (dwFlags=0): GetOverlappedResult resets the
+        // event when it returns successfully, so consecutive I/O calls
+        // that reuse the same OVERLAPPED+event don't need ResetEvent.
+        const read_event = windows.kernel32.CreateEventExW(null, null, 0, windows.EVENT_ALL_ACCESS) orelse return error.EventCreateFailed;
+        errdefer windows.CloseHandle(read_event);
+
+        const write_event = windows.kernel32.CreateEventExW(null, null, 0, windows.EVENT_ALL_ACCESS) orelse return error.EventCreateFailed;
+        errdefer windows.CloseHandle(write_event);
+
+        const self = try alloc.create(WindowsOverlappedPipe);
+        self.* = .{
+            .handle = handle,
+            .read_event = read_event,
+            .write_event = write_event,
+            .alloc = alloc,
+        };
+        return self;
+    }
+
+    pub fn deinit(self: *WindowsOverlappedPipe) void {
+        windows.CloseHandle(self.handle);
+        windows.CloseHandle(self.read_event);
+        windows.CloseHandle(self.write_event);
+        self.alloc.destroy(self);
+    }
+
+    /// Wait for an overlapped I/O to complete. Returns the byte count on
+    /// success; returns null on broken-pipe / EOF (i.e. read EOF, write
+    /// to closed pipe). Other errors propagate.
+    fn waitOverlapped(self: *WindowsOverlappedPipe, overlapped: *windows.OVERLAPPED) !?windows.DWORD {
+        var bytes: windows.DWORD = 0;
+        if (windows.kernel32.GetOverlappedResult(self.handle, overlapped, &bytes, @intFromBool(true)) == 0) {
+            return switch (windows.kernel32.GetLastError()) {
+                .BROKEN_PIPE, .HANDLE_EOF => null,
+                .OPERATION_ABORTED => error.OperationAborted,
+                .NETNAME_DELETED => error.ConnectionResetByPeer,
+                else => error.Unexpected,
+            };
+        }
+        return bytes;
+    }
+
+    /// Blocking read. Returns 0 on EOF (broken pipe). Uses overlapped
+    /// I/O so a concurrent writeAll() on the same handle doesn't block.
+    pub fn read(self: *WindowsOverlappedPipe, buf: []u8) !usize {
+        if (buf.len == 0) return 0;
+
+        var overlapped: windows.OVERLAPPED = std.mem.zeroes(windows.OVERLAPPED);
+        overlapped.hEvent = self.read_event;
+
+        const want: windows.DWORD = @intCast(@min(buf.len, std.math.maxInt(windows.DWORD)));
+        var bytes_read: windows.DWORD = 0;
+
+        const ok = windows.kernel32.ReadFile(self.handle, buf.ptr, want, &bytes_read, &overlapped);
+        if (ok == 0) {
+            switch (windows.kernel32.GetLastError()) {
+                .IO_PENDING => {}, // proceed to GetOverlappedResult below
+                .BROKEN_PIPE, .HANDLE_EOF => return 0,
+                .OPERATION_ABORTED => return error.OperationAborted,
+                .NETNAME_DELETED => return error.ConnectionResetByPeer,
+                else => return error.Unexpected,
+            }
+
+            const maybe_got = try self.waitOverlapped(&overlapped);
+            const got = maybe_got orelse return 0; // EOF
+            return @intCast(got);
+        }
+        return @intCast(bytes_read);
+    }
+
+    /// Blocking writeAll. Loops on partial writes (rare for pipes but
+    /// possible for very large buffers).
+    pub fn writeAll(self: *WindowsOverlappedPipe, bytes: []const u8) !void {
+        var idx: usize = 0;
+        while (idx < bytes.len) {
+            var overlapped: windows.OVERLAPPED = std.mem.zeroes(windows.OVERLAPPED);
+            overlapped.hEvent = self.write_event;
+
+            const want: windows.DWORD = @intCast(@min(bytes.len - idx, std.math.maxInt(windows.DWORD)));
+            var bytes_written: windows.DWORD = 0;
+
+            const ok = windows.kernel32.WriteFile(self.handle, bytes.ptr + idx, want, &bytes_written, &overlapped);
+            if (ok == 0) {
+                switch (windows.kernel32.GetLastError()) {
+                    .IO_PENDING => {}, // proceed to GetOverlappedResult below
+                    .BROKEN_PIPE => return error.BrokenPipe,
+                    .OPERATION_ABORTED => return error.OperationAborted,
+                    .NETNAME_DELETED => return error.ConnectionResetByPeer,
+                    else => return error.Unexpected,
+                }
+
+                const maybe_got = try self.waitOverlapped(&overlapped);
+                bytes_written = maybe_got orelse return error.BrokenPipe;
+            }
+
+            if (bytes_written == 0) return error.BrokenPipe;
+            idx += @as(usize, bytes_written);
+        }
+    }
+} else struct {
+    // POSIX stub: never instantiated. Methods are unreachable so the
+    // Stream switch arms type-check on POSIX even though .win_pipe is
+    // never constructed there.
+    pub fn open(_: std.mem.Allocator, _: []const u8) ConnectError!*@This() {
+        unreachable;
+    }
+    pub fn deinit(_: *@This()) void {
+        unreachable;
+    }
+    pub fn read(_: *@This(), _: []u8) !usize {
+        unreachable;
+    }
+    pub fn writeAll(_: *@This(), _: []const u8) !void {
+        unreachable;
     }
 };
 
@@ -73,7 +254,6 @@ fn isPipePath(addr: []const u8) bool {
     if (addr[3] != '\\') return false;
     const tail = addr[4..];
     if (tail.len < 5) return false;
-    // Match "pipe\" case-insensitively.
     if (std.ascii.toLower(tail[0]) != 'p') return false;
     if (std.ascii.toLower(tail[1]) != 'i') return false;
     if (std.ascii.toLower(tail[2]) != 'p') return false;
@@ -121,23 +301,26 @@ pub fn parseListenAddr(addr: []const u8) ?Parsed {
     return .{ .tcp = .{ .host = host, .port = port } };
 }
 
-/// Connect to a Neovim listen address and return a `Connection`. The
-/// connection's underlying fd is used for both read and write, and is
-/// closed exactly once at session teardown.
-///
-/// Windows: returns `error.UnsupportedOnWindows` for all forms today (see
-/// file header for the named-pipe deadlock rationale). The caller's
-/// re-spawn fallback handles `:restart` in degraded mode.
-pub fn connectListenAddr(alloc: std.mem.Allocator, addr: []const u8) ConnectError!Connection {
-    if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
-
+/// Connect to a Neovim listen address and return a `Stream`. The
+/// connection's underlying fd/HANDLE is used for both read and write,
+/// and is closed exactly once at session teardown via `Stream.close()`.
+pub fn connectListenAddr(alloc: std.mem.Allocator, addr: []const u8) ConnectError!Stream {
     const parsed = parseListenAddr(addr) orelse return error.InvalidAddress;
+
+    if (builtin.os.tag == .windows) {
+        return switch (parsed) {
+            .pipe => |p| .{ .win_pipe = try WindowsOverlappedPipe.open(alloc, p) },
+            // TCP on Windows would require a winsock SOCKET-as-HANDLE
+            // shim that the existing FrameReader/writer don't expose.
+            .tcp => error.UnsupportedOnWindows,
+            .unix => error.UnsupportedOnWindows,
+        };
+    }
 
     const stream = switch (parsed) {
         .tcp => |t| try std.net.tcpConnectToHost(alloc, t.host, t.port),
         .unix => |p| try std.net.connectUnixSocket(p),
-        // Pipe paths are Windows-only; the early return above already
-        // handled them for that platform.
+        // Pipe paths are Windows-only; the early return above handled it.
         .pipe => return error.UnsupportedOnPosix,
     };
 

--- a/test/mpack_bench.zig
+++ b/test/mpack_bench.zig
@@ -325,6 +325,8 @@ fn noopGuifont(_: *NoopCtx, _: []const u8) anyerror!void {}
 fn noopLinespace(_: *NoopCtx, _: i32) anyerror!void {}
 fn noopSetTitle(_: *NoopCtx, _: []const u8) anyerror!void {}
 fn noopDefaultColors(_: *NoopCtx, _: u32, _: u32) anyerror!void {}
+fn noopRestart(_: *NoopCtx, _: []const u8) anyerror!void {}
+fn noopConnect(_: *NoopCtx, _: []const u8) anyerror!void {}
 
 fn runOldFull(
     arena: std.mem.Allocator,
@@ -355,6 +357,8 @@ fn runOldFull(
         noopLinespace,
         noopSetTitle,
         noopDefaultColors,
+        noopRestart,
+        noopConnect,
     );
 }
 
@@ -391,6 +395,8 @@ fn runNewFull(
         noopLinespace,
         noopSetTitle,
         noopDefaultColors,
+        noopRestart,
+        noopConnect,
     );
 }
 

--- a/test/redraw_parity_test.zig
+++ b/test/redraw_parity_test.zig
@@ -49,6 +49,8 @@ const Stub = struct {
     last_linespace_px: i32 = 0,
     set_title_calls: u32 = 0,
     default_colors_calls: u32 = 0,
+    restart_calls: u32 = 0,
+    connect_calls: u32 = 0,
 
     fn onFlush(ctx: *Stub, rows: u32, cols: u32) anyerror!void {
         ctx.flush_calls += 1;
@@ -67,6 +69,12 @@ const Stub = struct {
     }
     fn onDefaultColors(ctx: *Stub, _: u32, _: u32) anyerror!void {
         ctx.default_colors_calls += 1;
+    }
+    fn onRestart(ctx: *Stub, _: []const u8) anyerror!void {
+        ctx.restart_calls += 1;
+    }
+    fn onConnect(ctx: *Stub, _: []const u8) anyerror!void {
+        ctx.connect_calls += 1;
     }
 };
 
@@ -142,6 +150,8 @@ fn runValueTreePath(frame_bytes: []const u8, w: *World) !void {
         Stub.onLinespace,
         Stub.onSetTitle,
         Stub.onDefaultColors,
+        Stub.onRestart,
+        Stub.onConnect,
     );
 }
 
@@ -169,6 +179,8 @@ fn runStreamingPath(frame_bytes: []const u8, w: *World) !void {
         Stub.onLinespace,
         Stub.onSetTitle,
         Stub.onDefaultColors,
+        Stub.onRestart,
+        Stub.onConnect,
     );
 }
 

--- a/windows/app.zig
+++ b/windows/app.zig
@@ -27,6 +27,7 @@ pub const zonvie_callbacks = core.zonvie_callbacks;
 pub const zonvie_core_create = core.zonvie_core_create;
 pub const zonvie_core_destroy = core.zonvie_core_destroy;
 pub const zonvie_core_start = core.zonvie_core_start;
+pub const zonvie_core_start_connect = core.zonvie_core_start_connect;
 pub const zonvie_core_stop = core.zonvie_core_stop;
 pub const zonvie_core_notify_layout_ready = core.zonvie_core_notify_layout_ready;
 pub const zonvie_core_send_input = core.zonvie_core_send_input;
@@ -2748,6 +2749,12 @@ pub const App = struct {
     devcontainer_rebuild: bool = false,
     devcontainer_up_pending: bool = false, // Waiting for devcontainer up to complete
     devcontainer_nvim_started: bool = false, // Nvim started in devcontainer mode
+
+    // Connect mode (--connect-nvim=<addr> or --remote-ui=<addr>): attach to a
+    // running Neovim server instead of spawning. When set, doEarlyCoreInit
+    // calls zonvie_core_start_connect with this address. Mutually exclusive
+    // with wsl/ssh/devcontainer modes (CLI parsing rejects mixed use).
+    connect_addr: ?[]const u8 = null,
 
     // Extra arguments to pass to nvim (not recognized as zonvie arguments)
     nvim_extra_args: std.ArrayListUnmanaged([]const u8) = .{},

--- a/windows/app.zig
+++ b/windows/app.zig
@@ -250,6 +250,16 @@ pub const PendingExternalWindow = struct {
     cols: u32,
     start_row: i32, // -1 if no position info (cmdline, etc.)
     start_col: i32,
+    /// Monotonic identifier assigned by onExternalWindow at enqueue.
+    /// The corresponding WM_APP_CREATE_EXTERNAL_WINDOW message carries
+    /// this value in lParam so the UI-thread handler can dequeue the
+    /// exact request the message was posted for. Without this, an old-
+    /// session WM_APP_CREATE message could pick up a same-grid_id new-
+    /// session request that landed in the queue after a session reset.
+    /// Coalescing same-grid_id requests in onExternalWindow preserves
+    /// the existing entry's seq so the original posted message still
+    /// matches.
+    seq: u64,
 };
 
 /// CPU-side surface state shared between external windows and pending
@@ -2499,6 +2509,14 @@ pub const App = struct {
 
     // Pending external window creation requests (for UI thread processing)
     pending_external_windows: std.ArrayListUnmanaged(PendingExternalWindow) = .{},
+
+    // Monotonically increasing identifier assigned to each
+    // PendingExternalWindow at enqueue. Used to bind WM_APP_CREATE_
+    // EXTERNAL_WINDOW messages 1:1 to their request: a stale message
+    // (e.g., posted by a previous session whose request was removed
+    // by onExternalWindowClose) won't dequeue an unrelated new-session
+    // request whose seq doesn't match the message's lParam.
+    pending_external_seq_counter: u64 = 0,
 
     // Pending position for next external window (set by tab externalization)
     pending_external_window_position: ?struct { x: c_int, y: c_int } = null,

--- a/windows/callbacks.zig
+++ b/windows/callbacks.zig
@@ -2263,6 +2263,30 @@ pub fn onLineSpace(ctx: ?*anyopaque, linespace_px: i32) callconv(.c) void {
 // Exit / IME / quit / title callbacks
 // =========================================================================
 
+pub fn onRestart(ctx: ?*anyopaque, addr_ptr: ?[*]const u8, addr_len: usize) callconv(.c) void {
+    _ = ctx;
+    if (!applog.isEnabled()) return;
+    if (addr_ptr) |p| {
+        applog.appLog("[win] on_restart: reconnecting to listen_addr={s}\n", .{p[0..addr_len]});
+    } else {
+        applog.appLog("[win] on_restart: (no listen_addr)\n", .{});
+    }
+}
+
+/// Receive the `connect` UI event (`:connect <addr>`). Same flicker-free
+/// reconnect as restart; the only difference is that the previous server
+/// keeps running headless instead of dying. The core handles the actual
+/// hot-swap; this callback is informational only.
+pub fn onConnect(ctx: ?*anyopaque, addr_ptr: ?[*]const u8, addr_len: usize) callconv(.c) void {
+    _ = ctx;
+    if (!applog.isEnabled()) return;
+    if (addr_ptr) |p| {
+        applog.appLog("[win] on_connect: hot-swap to server_addr={s}\n", .{p[0..addr_len]});
+    } else {
+        applog.appLog("[win] on_connect: (no server_addr)\n", .{});
+    }
+}
+
 pub fn onExit(ctx: ?*anyopaque, exit_code: i32) callconv(.c) void {
     const app: *App = @ptrCast(@alignCast(ctx.?));
     if (applog.isEnabled()) applog.appLog("[win] on_exit: code={d}\n", .{exit_code});

--- a/windows/main.zig
+++ b/windows/main.zig
@@ -263,6 +263,11 @@ pub fn main() u8 {
     var devcontainer_workspace: ?[]const u8 = null;
     var devcontainer_config: ?[]const u8 = null;
     var devcontainer_rebuild: bool = false;
+
+    // Connect mode (--connect-nvim=<addr> / --remote-ui=<addr>): attach to a
+    // running Neovim server instead of spawning. Mutually exclusive with
+    // wsl/ssh/devcontainer modes; if combined, connect mode wins.
+    var connect_addr: ?[]const u8 = null;
     const args = std.process.argsAlloc(alloc) catch return 1;
     defer std.process.argsFree(alloc, args);
 
@@ -295,6 +300,10 @@ pub fn main() u8 {
                     \\    --devcontainer=<workspace>    Run inside a devcontainer
                     \\    --devcontainer-config=<path>  Path to devcontainer.json
                     \\    --devcontainer-rebuild        Rebuild devcontainer before starting
+                    \\    --connect-nvim=<addr>         Attach to a running Neovim server.
+                    \\                                    Address: TCP "host:port" or Unix socket path.
+                    \\                                    Mutually exclusive with --ssh / --devcontainer / --wsl.
+                    \\    --remote-ui=<addr>            Alias of --connect-nvim, mirrors `nvim --remote-ui`.
                     \\    --install                     First-launch setup (icon + default config) and exit
                     \\    --help, -h                    Show this help message and exit
                     \\    --                            Pass all remaining arguments to nvim
@@ -515,6 +524,24 @@ pub fn main() u8 {
         } else if (std.mem.eql(u8, arg, "--devcontainer-rebuild")) {
             devcontainer_rebuild = true;
             if (applog.isEnabled()) applog.appLog("[win] --devcontainer-rebuild flag detected\n", .{});
+        } else if (std.mem.startsWith(u8, arg, "--connect-nvim=")) {
+            connect_addr = arg["--connect-nvim=".len..];
+            if (applog.isEnabled()) applog.appLog("[win] --connect-nvim={s} flag detected\n", .{connect_addr.?});
+        } else if (std.mem.eql(u8, arg, "--connect-nvim")) {
+            if (i + 1 < args.len) {
+                connect_addr = args[i + 1];
+                i += 1;
+                if (applog.isEnabled()) applog.appLog("[win] --connect-nvim {s} flag detected\n", .{connect_addr.?});
+            }
+        } else if (std.mem.startsWith(u8, arg, "--remote-ui=")) {
+            connect_addr = arg["--remote-ui=".len..];
+            if (applog.isEnabled()) applog.appLog("[win] --remote-ui={s} flag detected (alias of --connect-nvim)\n", .{connect_addr.?});
+        } else if (std.mem.eql(u8, arg, "--remote-ui")) {
+            if (i + 1 < args.len) {
+                connect_addr = args[i + 1];
+                i += 1;
+                if (applog.isEnabled()) applog.appLog("[win] --remote-ui {s} flag detected (alias of --connect-nvim)\n", .{connect_addr.?});
+            }
         } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             // Already handled above, skip
         } else {
@@ -607,6 +634,7 @@ pub fn main() u8 {
         .devcontainer_workspace = devcontainer_workspace,
         .devcontainer_config = devcontainer_config,
         .devcontainer_rebuild = devcontainer_rebuild,
+        .connect_addr = connect_addr,
         .nvim_extra_args = nvim_extra_args,
         .cli_nvim_path = cli_nvim_path,
     };

--- a/windows/main.zig
+++ b/windows/main.zig
@@ -264,15 +264,21 @@ pub fn main() u8 {
     var devcontainer_config: ?[]const u8 = null;
     var devcontainer_rebuild: bool = false;
 
-    // Connect mode (--connect-nvim=<addr> / --remote-ui=<addr>): attach to a
-    // running Neovim server instead of spawning. Mutually exclusive with
-    // wsl/ssh/devcontainer modes; if combined, connect mode wins.
+    // Connect mode (--connect-nvim=<addr> / --remote-ui=<addr>): attach to
+    // a running Neovim server instead of spawning. Mutually exclusive with
+    // --wsl / --ssh / --devcontainer (and their config.toml equivalents
+    // [neovim].wsl / .ssh). The combination is rejected up-front below,
+    // before the App is constructed; see the validation block right after
+    // argv parsing.
     var connect_addr: ?[]const u8 = null;
     const args = std.process.argsAlloc(alloc) catch return 1;
     defer std.process.argsFree(alloc, args);
 
-    // Check for --help / -h first
+    // Check for --help / -h first. Stop at `--` so `zonvie -- --help` /
+    // `zonvie -- --install` forward those tokens to nvim instead of
+    // triggering zonvie's own help / installer.
     for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--")) break;
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             // Attach to parent console for stdout output
             _ = c.AttachConsole(ATTACH_PARENT_PROCESS);
@@ -301,7 +307,9 @@ pub fn main() u8 {
                     \\    --devcontainer-config=<path>  Path to devcontainer.json
                     \\    --devcontainer-rebuild        Rebuild devcontainer before starting
                     \\    --connect-nvim=<addr>         Attach to a running Neovim server.
-                    \\                                    Address: TCP "host:port" or Unix socket path.
+                    \\                                    Address: Windows named pipe path,
+                    \\                                    e.g. "\\\\.\\pipe\\nvim.31920.0".
+                    \\                                    (TCP / Unix sockets: not yet supported on Windows.)
                     \\                                    Mutually exclusive with --ssh / --devcontainer / --wsl.
                     \\    --remote-ui=<addr>            Alias of --connect-nvim, mirrors `nvim --remote-ui`.
                     \\    --install                     First-launch setup (icon + default config) and exit
@@ -532,6 +540,13 @@ pub fn main() u8 {
                 connect_addr = args[i + 1];
                 i += 1;
                 if (applog.isEnabled()) applog.appLog("[win] --connect-nvim {s} flag detected\n", .{connect_addr.?});
+            } else {
+                // Mark connect mode requested but value missing. The empty
+                // slice flows into the validation block below where we
+                // refuse to start instead of silently falling through to
+                // a regular nvim spawn.
+                connect_addr = "";
+                if (applog.isEnabled()) applog.appLog("[win] --connect-nvim flag detected without value\n", .{});
             }
         } else if (std.mem.startsWith(u8, arg, "--remote-ui=")) {
             connect_addr = arg["--remote-ui=".len..];
@@ -541,6 +556,9 @@ pub fn main() u8 {
                 connect_addr = args[i + 1];
                 i += 1;
                 if (applog.isEnabled()) applog.appLog("[win] --remote-ui {s} flag detected (alias of --connect-nvim)\n", .{connect_addr.?});
+            } else {
+                connect_addr = "";
+                if (applog.isEnabled()) applog.appLog("[win] --remote-ui flag detected without value\n", .{});
             }
         } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             // Already handled above, skip
@@ -609,6 +627,91 @@ pub fn main() u8 {
 
     if (c.RegisterClassExW(&wc) == 0) return 1;
 
+
+    // Reject empty / missing connect address. Catches both
+    // `zonvie --connect-nvim` (bare flag, no value) and
+    // `zonvie --connect-nvim=` (`=` with nothing after). Without this
+    // check the previous behavior was: bare flag silently fell through
+    // to a regular nvim spawn (surprising), and empty-after-`=` flowed
+    // into the core which returned -3 anyway but only after the run-
+    // thread spin-up. Rejecting here keeps the failure synchronous and
+    // gives the user a clear message.
+    if (connect_addr) |ca| {
+        if (ca.len == 0) {
+            _ = c.AttachConsole(ATTACH_PARENT_PROCESS);
+            const stderr = c.GetStdHandle(c.STD_ERROR_HANDLE);
+            if (stderr != c.INVALID_HANDLE_VALUE) {
+                var written: c.DWORD = 0;
+                const m = "zonvie: --connect-nvim / --remote-ui requires a non-empty address (e.g. \\\\.\\pipe\\nvim.31920.0). On Windows only named pipes are supported.\r\n";
+                _ = c.WriteFile(stderr, m.ptr, @intCast(m.len), &written, null);
+            }
+            const wide_title = comptime blk: {
+                const t = "zonvie: invalid options";
+                var buf: [t.len + 1]u16 = undefined;
+                for (t, 0..) |ch, idx| buf[idx] = ch;
+                buf[t.len] = 0;
+                break :blk buf;
+            };
+            const wide_msg = comptime blk: {
+                const m = "--connect-nvim / --remote-ui requires a non-empty address such as \\\\.\\pipe\\nvim.31920.0. On Windows only named pipes are supported.";
+                var buf: [m.len + 1]u16 = undefined;
+                for (m, 0..) |ch, idx| buf[idx] = ch;
+                buf[m.len] = 0;
+                break :blk buf;
+            };
+            _ = c.MessageBoxW(null, &wide_msg, &wide_title, c.MB_OK | c.MB_ICONERROR);
+            return 1;
+        }
+    }
+
+    // Validate flag exclusivity: --connect-nvim attaches to an already-
+    // running Neovim server, while --wsl / --ssh / --devcontainer (and
+    // their config-file equivalents [neovim].wsl / .ssh) all SPAWN a
+    // wrapper-hosted nvim. The two are mutually exclusive — silently
+    // letting connect mode override (the previous behavior) would pick
+    // the user's wrapper config out from under them. Refuse to start so
+    // the user can fix the invocation explicitly.
+    if (connect_addr != null and (wsl_mode or ssh_mode or devcontainer_mode)) {
+        _ = c.AttachConsole(ATTACH_PARENT_PROCESS);
+        const stderr = c.GetStdHandle(c.STD_ERROR_HANDLE);
+        if (stderr != c.INVALID_HANDLE_VALUE) {
+            var written: c.DWORD = 0;
+            const m1 = "zonvie: --connect-nvim is mutually exclusive with";
+            _ = c.WriteFile(stderr, m1.ptr, @intCast(m1.len), &written, null);
+            if (wsl_mode) {
+                const m = " --wsl";
+                _ = c.WriteFile(stderr, m.ptr, @intCast(m.len), &written, null);
+            }
+            if (ssh_mode) {
+                const m = " --ssh";
+                _ = c.WriteFile(stderr, m.ptr, @intCast(m.len), &written, null);
+            }
+            if (devcontainer_mode) {
+                const m = " --devcontainer";
+                _ = c.WriteFile(stderr, m.ptr, @intCast(m.len), &written, null);
+            }
+            const m2 = " (or [neovim].wsl/[neovim].ssh in config.toml).\r\nRemove the conflicting option(s) and retry.\r\n";
+            _ = c.WriteFile(stderr, m2.ptr, @intCast(m2.len), &written, null);
+        }
+        // Also surface via MessageBox for Explorer / shortcut launches
+        // where there is no parent console.
+        const wide_title = comptime blk: {
+            const t = "zonvie: invalid options";
+            var buf: [t.len + 1]u16 = undefined;
+            for (t, 0..) |ch, idx| buf[idx] = ch;
+            buf[t.len] = 0;
+            break :blk buf;
+        };
+        const wide_msg = comptime blk: {
+            const m = "--connect-nvim is mutually exclusive with --wsl / --ssh / --devcontainer (or their config.toml equivalents). Remove the conflicting option(s) and retry.";
+            var buf: [m.len + 1]u16 = undefined;
+            for (m, 0..) |ch, idx| buf[idx] = ch;
+            buf[m.len] = 0;
+            break :blk buf;
+        };
+        _ = c.MessageBoxW(null, &wide_msg, &wide_title, c.MB_OK | c.MB_ICONERROR);
+        return 1;
+    }
 
     const app = alloc.create(App) catch return 1;
     // errdefer alloc.destroy(app); // ← Remove this (causes double-free)

--- a/windows/ui/external_windows.zig
+++ b/windows/ui/external_windows.zig
@@ -536,13 +536,56 @@ pub fn onExternalWindow(ctx: ?*anyopaque, grid_id: i64, win: i64, rows: u32, col
     app.mu.lock();
     defer app.mu.unlock();
 
-    // Check if already exists
-    if (app.external_windows.get(grid_id) != null) {
-        if (applog.isEnabled()) applog.appLog("[win] external window already exists for grid_id={d}\n", .{grid_id});
-        return;
+    // Check if already exists. If the existing entry is is_pending_close
+    // (queued for destruction by an earlier on_external_window_close —
+    // typically from resetSessionState clearing channel-bound state at a
+    // :restart / :connect boundary), we must NOT short-circuit: the new
+    // session can legitimately reuse the same grid_id, and rejecting it
+    // here would leave the new server's window unattached. The pending
+    // close message is already in the UI thread queue ahead of the
+    // create message we are about to post, so FIFO ordering guarantees
+    // the old window is destroyed before the new one is created.
+    if (app.external_windows.get(grid_id)) |existing| {
+        if (!existing.is_pending_close) {
+            if (applog.isEnabled()) applog.appLog("[win] external window already exists for grid_id={d}\n", .{grid_id});
+            return;
+        }
+        if (applog.isEnabled()) applog.appLog("[win] external window for grid_id={d} is pending close; queueing new request behind it\n", .{grid_id});
     }
 
-    // Queue the request for UI thread processing
+    // Coalesce: if the queue already has a request for this grid_id (UI
+    // thread hasn't dequeued it yet, or all pending entries for this
+    // grid_id are blocked by an is_pending_close existing window),
+    // replace its mutable fields in place but PRESERVE the existing
+    // entry's seq. The original WM_APP_CREATE_EXTERNAL_WINDOW message
+    // already in the UI queue carries that seq in lParam, and the
+    // handler will dequeue exactly the entry whose seq matches —
+    // guaranteeing the (replaced) data, not stale fields, gets used.
+    //
+    // Without coalesce, multiple enqueues for the same grid_id would
+    // each spawn a createExternalWindowOnUIThread; the second put()
+    // would overwrite the first window's HWND in external_windows —
+    // leaking the first and confusing the close handler.
+    for (app.pending_external_windows.items, 0..) |item, i| {
+        if (item.grid_id == grid_id) {
+            app.pending_external_windows.items[i] = .{
+                .grid_id = grid_id,
+                .win = win,
+                .rows = rows,
+                .cols = cols,
+                .start_row = start_row,
+                .start_col = start_col,
+                .seq = item.seq, // preserve so existing in-flight message still matches
+            };
+            if (applog.isEnabled()) applog.appLog("[win] coalesced pending external window request for grid_id={d} (seq={d})\n", .{ grid_id, item.seq });
+            return;
+        }
+    }
+
+    // No existing pending entry: take a fresh seq, append, post.
+    const seq = app.pending_external_seq_counter;
+    app.pending_external_seq_counter += 1;
+
     app.pending_external_windows.append(app.alloc, .{
         .grid_id = grid_id,
         .win = win,
@@ -550,14 +593,13 @@ pub fn onExternalWindow(ctx: ?*anyopaque, grid_id: i64, win: i64, rows: u32, col
         .cols = cols,
         .start_row = start_row,
         .start_col = start_col,
+        .seq = seq,
     }) catch |e| {
         if (applog.isEnabled()) applog.appLog("[win] failed to queue external window request: {any}\n", .{e});
         return;
     };
-
-    // Post message to UI thread to create the window
     if (app.hwnd) |main_hwnd| {
-        _ = c.PostMessageW(main_hwnd, app_mod.WM_APP_CREATE_EXTERNAL_WINDOW, 0, 0);
+        _ = c.PostMessageW(main_hwnd, app_mod.WM_APP_CREATE_EXTERNAL_WINDOW, 0, @bitCast(seq));
     }
 }
 
@@ -892,6 +934,36 @@ pub fn createExternalWindowOnUIThread(app: *App, req: app_mod.PendingExternalWin
 
     app.mu.lock();
 
+    // Defense-in-depth: refuse to overwrite a live external_windows entry
+    // (i.e., one that is NOT is_pending_close). The main caller flow
+    // already coalesces same-grid_id requests in pending_external_windows
+    // and the WM_APP_CREATE_EXTERNAL_WINDOW handler skips items blocked
+    // by an is_pending_close entry, so reaching this branch implies a
+    // bug elsewhere — but if we did put() over a live entry, the old
+    // HWND would leak and the close handler would later destroy whichever
+    // entry is currently in the map (the new one). Tear down our just-
+    // created HWND/renderer instead.
+    if (app.external_windows.get(req.grid_id)) |existing| {
+        if (!existing.is_pending_close) {
+            app.mu.unlock();
+            if (applog.isEnabled()) applog.appLog("[win] createExternalWindowOnUIThread: live entry for grid_id={d} would be overwritten; aborting (probable upstream coalesce miss)\n", .{req.grid_id});
+            var tmp_renderer = renderer;
+            tmp_renderer.deinit();
+            _ = c.DestroyWindow(hwnd);
+            return;
+        }
+        // is_pending_close: should have been filtered by the
+        // WM_APP_CREATE_EXTERNAL_WINDOW blocked-skip path. Reaching
+        // here means we got dequeued before close ran — also a bug.
+        // Same teardown response.
+        app.mu.unlock();
+        if (applog.isEnabled()) applog.appLog("[win] createExternalWindowOnUIThread: pending-close entry for grid_id={d} still in map; aborting (close not yet completed)\n", .{req.grid_id});
+        var tmp_renderer = renderer;
+        tmp_renderer.deinit();
+        _ = c.DestroyWindow(hwnd);
+        return;
+    }
+
     // Store external window
     const ext_window = app_mod.ExternalWindow{
         .hwnd = hwnd.?,
@@ -1067,13 +1139,35 @@ pub fn onExternalWindowClose(ctx: ?*anyopaque, grid_id: i64) callconv(.c) void {
     if (applog.isEnabled()) applog.appLog("[win] on_external_window_close: grid_id={d}\n", .{grid_id});
 
     // Mark the window as pending close (don't remove from HashMap yet to avoid use-after-free)
-    // The actual removal and cleanup will happen on the UI thread in closeExternalWindowOnUIThread
+    // The actual removal and cleanup will happen on the UI thread in closeExternalWindowOnUIThread.
+    //
+    // Drop any pending_external_windows entries for this grid_id. They
+    // belong to the OLD session (resetSessionState fires this callback
+    // before the new session can enqueue anything for this grid_id),
+    // so removing them here prevents an old in-flight WM_APP_CREATE
+    // message from later picking up an unrelated new-session entry.
+    // The seq tag on each entry is unique so the old WM_APP_CREATE
+    // message — which carries the removed entry's seq in lParam —
+    // will find no match and be a no-op when the UI thread processes it.
     app.mu.lock();
     const main_hwnd = app.hwnd;
     if (app.external_windows.getPtr(grid_id)) |ext_win| {
         ext_win.is_pending_close = true;
     }
+    var i: usize = 0;
+    var removed: usize = 0;
+    while (i < app.pending_external_windows.items.len) {
+        if (app.pending_external_windows.items[i].grid_id == grid_id) {
+            _ = app.pending_external_windows.orderedRemove(i);
+            removed += 1;
+        } else {
+            i += 1;
+        }
+    }
     app.mu.unlock();
+    if (removed > 0 and applog.isEnabled()) {
+        applog.appLog("[win] on_external_window_close: dropped {d} stale pending request(s) for grid_id={d}\n", .{ removed, grid_id });
+    }
 
     // Post message to UI thread to do the actual close
     // (DestroyWindow must be called from the thread that created the window)
@@ -1156,6 +1250,41 @@ pub fn closeExternalWindowOnUIThread(app: *App, grid_id: i64) void {
     // Note: We intentionally do NOT remove pending_external_verts here because
     // the pending verts might belong to a new window with the same grid_id that
     // was created after the close event was queued but before this handler ran.
+    //
+    // Likewise we do NOT remove pending_external_windows entries by grid_id.
+    // The new session can legitimately enqueue a same-grid_id create after
+    // we posted WM_APP_CLOSE_EXTERNAL_WINDOW, and we cannot tell those
+    // apart from old-session entries by grid_id alone.
+    //
+    // Wake any pending creates that were blocked by our is_pending_close
+    // entry. The WM_APP_CREATE_EXTERNAL_WINDOW handler skips queue items
+    // whose grid_id is held by an is_pending_close entry (to avoid
+    // racing with paint that still holds a pointer into ext_win); now
+    // that we have removed the old entry from external_windows, those
+    // items are safe to dequeue. Re-post one create message per matching
+    // pending entry, carrying the entry's seq so the handler picks up
+    // the right one. (Coalesce in onExternalWindow keeps the pending
+    // count <=1 per grid_id, but iterate the full set defensively.)
+    if (entry != null) {
+        app.mu.lock();
+        var seqs_buf: [8]u64 = undefined;
+        var seq_count: usize = 0;
+        for (app.pending_external_windows.items) |item| {
+            if (item.grid_id == grid_id and seq_count < seqs_buf.len) {
+                seqs_buf[seq_count] = item.seq;
+                seq_count += 1;
+            }
+        }
+        app.mu.unlock();
+        if (seq_count > 0) {
+            if (applog.isEnabled()) applog.appLog("[win] closeExternalWindowOnUIThread: waking {d} pending create(s) for grid_id={d}\n", .{ seq_count, grid_id });
+            if (app.hwnd) |main_hwnd| {
+                for (seqs_buf[0..seq_count]) |seq| {
+                    _ = c.PostMessageW(main_hwnd, app_mod.WM_APP_CREATE_EXTERNAL_WINDOW, 0, @bitCast(seq));
+                }
+            }
+        }
+    }
 }
 
 pub fn onCursorGridChanged(ctx: ?*anyopaque, grid_id: i64) callconv(.c) void {

--- a/windows/window.zig
+++ b/windows/window.zig
@@ -153,6 +153,8 @@ fn makeCoreCbs() core.Callbacks {
         .on_exit = callbacks.onExit,
         .on_default_colors_set = callbacks.onDefaultColorsSet,
         .on_set_title = callbacks.onSetTitle,
+        .on_restart = callbacks.onRestart,
+        .on_connect = callbacks.onConnect,
         .on_external_window = external_windows.onExternalWindow,
         .on_external_window_close = external_windows.onExternalWindowClose,
         .on_cursor_grid_changed = external_windows.onCursorGridChanged,
@@ -291,15 +293,21 @@ fn doEarlyCoreInit(hwnd: c.HWND, app: *App) !void {
     // 5. Compute rows/cols from actual cell metrics
     updateRowsColsFromClientForce(hwnd, app);
 
-    // 6. Spawn nvim (native mode only)
-    var nvim_cmd_buf: [1024]u8 = undefined;
-    const nvim_cmd_slice = buildNativeNvimCmd(app, &nvim_cmd_buf);
-    const nvim_path_z = app.alloc.dupeZ(u8, nvim_cmd_slice) catch null;
-    defer if (nvim_path_z) |p| app.alloc.free(p);
-    const nvim_path_ptr: ?[*:0]const u8 = if (nvim_path_z) |p| p.ptr else null;
+    // 6. Start session: connect mode if --connect-nvim/--remote-ui was set,
+    //    otherwise spawn nvim (native mode).
+    if (app.connect_addr) |addr| {
+        if (log_enabled) applog.appLog("[win] doEarlyCoreInit: connect mode addr={s} rows={d} cols={d}\n", .{ addr, app.surface.rows, app.surface.cols });
+        _ = core.zonvie_core_start_connect(app.corep, addr.ptr, addr.len, app.surface.rows, app.surface.cols);
+    } else {
+        var nvim_cmd_buf: [1024]u8 = undefined;
+        const nvim_cmd_slice = buildNativeNvimCmd(app, &nvim_cmd_buf);
+        const nvim_path_z = app.alloc.dupeZ(u8, nvim_cmd_slice) catch null;
+        defer if (nvim_path_z) |p| app.alloc.free(p);
+        const nvim_path_ptr: ?[*:0]const u8 = if (nvim_path_z) |p| p.ptr else null;
 
-    if (log_enabled) applog.appLog("[win] doEarlyCoreInit: starting nvim rows={d} cols={d}\n", .{ app.surface.rows, app.surface.cols });
-    _ = core.zonvie_core_start(app.corep, nvim_path_ptr, app.surface.rows, app.surface.cols);
+        if (log_enabled) applog.appLog("[win] doEarlyCoreInit: spawning nvim rows={d} cols={d}\n", .{ app.surface.rows, app.surface.cols });
+        _ = core.zonvie_core_start(app.corep, nvim_path_ptr, app.surface.rows, app.surface.cols);
+    }
     app.nvim_spawned = true;
     app.early_core_init_done = true;
 

--- a/windows/window.zig
+++ b/windows/window.zig
@@ -1925,18 +1925,49 @@ pub export fn WndProc(
                 // This ensures colors are available for popupmenu even if cmdline wasn't shown
                 external_windows.updateExternalWindowColors(app);
 
-                // Process all pending external window requests
+                // Dequeue the single pending request whose seq matches the
+                // one posted in lParam. Each onExternalWindow enqueue posts
+                // one message tagged with the request's seq, so messages
+                // bind 1:1 to specific requests — even if the request was
+                // later coalesced (same grid_id, fields replaced, seq kept)
+                // or removed (e.g., dropped from a previous session by
+                // onExternalWindowClose), the lookup remains unambiguous.
+                //
+                // Skip if the matching entry's grid_id is currently held
+                // by an is_pending_close entry in external_windows (close
+                // received but deferred because paint was in progress).
+                // Creating now would put() over the old entry while paint
+                // still references it, leaking the old HWND. Leave the
+                // request in the queue; closeExternalWindowOnUIThread re-
+                // posts WM_APP_CREATE with the same seq after the destroy
+                // completes, and the next pass will find the slot free.
+                const msg_seq: u64 = @bitCast(lParam);
                 app.mu.lock();
-                const pending = app.pending_external_windows.toOwnedSlice(app.alloc) catch {
+                var dequeue_idx: ?usize = null;
+                for (app.pending_external_windows.items, 0..) |item, i| {
+                    if (item.seq != msg_seq) continue;
+                    const blocked = if (app.external_windows.get(item.grid_id)) |e| e.is_pending_close else false;
+                    if (blocked) {
+                        // Matching entry exists but is blocked — leave
+                        // it; the deferred close will re-post a wake.
+                        app.mu.unlock();
+                        return 0;
+                    }
+                    dequeue_idx = i;
+                    break;
+                }
+                if (dequeue_idx == null) {
+                    // No matching pending entry. Either the request was
+                    // removed by onExternalWindowClose (old session) or
+                    // it was already dequeued by an earlier same-seq
+                    // wake message. Either way, this is a no-op.
                     app.mu.unlock();
                     return 0;
-                };
+                }
+                const req = app.pending_external_windows.orderedRemove(dequeue_idx.?);
                 app.mu.unlock();
 
-                for (pending) |req| {
-                    external_windows.createExternalWindowOnUIThread(app, req);
-                }
-                app.alloc.free(pending);
+                external_windows.createExternalWindowOnUIThread(app, req);
             }
             return 0;
         },

--- a/windows/window.zig
+++ b/windows/window.zig
@@ -294,11 +294,16 @@ fn doEarlyCoreInit(hwnd: c.HWND, app: *App) !void {
     updateRowsColsFromClientForce(hwnd, app);
 
     // 6. Start session: connect mode if --connect-nvim/--remote-ui was set,
-    //    otherwise spawn nvim (native mode).
-    if (app.connect_addr) |addr| {
+    //    otherwise spawn nvim (native mode). Capture the int return: a
+    //    negative value means the core thread was NOT started (-1 invalid
+    //    handle, -2 thread spawn failed, -3 invalid/unsupported listen
+    //    address). on_exit will not fire in that case, so we must abort
+    //    startup ourselves instead of leaving a zombie window with no
+    //    backing nvim.
+    const start_rc: i32 = if (app.connect_addr) |addr| blk: {
         if (log_enabled) applog.appLog("[win] doEarlyCoreInit: connect mode addr={s} rows={d} cols={d}\n", .{ addr, app.surface.rows, app.surface.cols });
-        _ = core.zonvie_core_start_connect(app.corep, addr.ptr, addr.len, app.surface.rows, app.surface.cols);
-    } else {
+        break :blk core.zonvie_core_start_connect(app.corep, addr.ptr, addr.len, app.surface.rows, app.surface.cols);
+    } else blk: {
         var nvim_cmd_buf: [1024]u8 = undefined;
         const nvim_cmd_slice = buildNativeNvimCmd(app, &nvim_cmd_buf);
         const nvim_path_z = app.alloc.dupeZ(u8, nvim_cmd_slice) catch null;
@@ -306,7 +311,21 @@ fn doEarlyCoreInit(hwnd: c.HWND, app: *App) !void {
         const nvim_path_ptr: ?[*:0]const u8 = if (nvim_path_z) |p| p.ptr else null;
 
         if (log_enabled) applog.appLog("[win] doEarlyCoreInit: spawning nvim rows={d} cols={d}\n", .{ app.surface.rows, app.surface.cols });
-        _ = core.zonvie_core_start(app.corep, nvim_path_ptr, app.surface.rows, app.surface.cols);
+        break :blk core.zonvie_core_start(app.corep, nvim_path_ptr, app.surface.rows, app.surface.cols);
+    };
+
+    if (start_rc != 0) {
+        if (log_enabled) applog.appLog("[win] doEarlyCoreInit: core start failed rc={d}; aborting startup\n", .{start_rc});
+        // Mark the session as already exited so the WM_CLOSE handler
+        // takes the fast path (no quit dialog, no waiting on the core).
+        app.neovim_exited.store(true, .release);
+        // Set the global exit code so wWinMain returns 1 to the shell
+        // (mirrors macOS Darwin.exit(1)). main.zig pulls this value
+        // out of g_exit_code after the message loop exits — the
+        // wParam passed to PostQuitMessage is intentionally ignored.
+        app_mod.g_exit_code.store(1, .seq_cst);
+        _ = c.PostMessageW(hwnd, c.WM_CLOSE, 0, 0);
+        return;
     }
     app.nvim_spawned = true;
     app.early_core_init_done = true;
@@ -2704,7 +2723,14 @@ pub export fn WndProc(
                         const nvim_path_z = app.alloc.dupeZ(u8, nvim_cmd_slice) catch null;
                         defer if (nvim_path_z) |p| app.alloc.free(p);
                         const nvim_path_ptr: ?[*:0]const u8 = if (nvim_path_z) |p| p.ptr else null;
-                        _ = core.zonvie_core_start(app.corep, nvim_path_ptr, app.surface.rows, app.surface.cols);
+                        const start_rc = core.zonvie_core_start(app.corep, nvim_path_ptr, app.surface.rows, app.surface.cols);
+                        if (start_rc != 0) {
+                            if (applog.isEnabled()) applog.appLog("[win] devcontainer-up: core start failed rc={d}; aborting\n", .{start_rc});
+                            app.neovim_exited.store(true, .release);
+                            app_mod.g_exit_code.store(1, .seq_cst);
+                            _ = c.PostMessageW(hwnd, c.WM_CLOSE, 0, 0);
+                            return 0;
+                        }
                         app.nvim_spawned = true;
                         if (app.devcontainer_mode and !app.devcontainer_rebuild) {
                             dialogs.hideDevcontainerProgressDialog();
@@ -4022,7 +4048,9 @@ pub export fn WndProc(
                     tray.remove();
                 }
             }
-            // Nvy style: PostQuitMessage(0), exit code returned from main()
+            // Nvy style: PostQuitMessage(0). The actual exit code is
+            // pulled from app_mod.g_exit_code by wWinMain after the
+            // message loop exits, so the wParam here is irrelevant.
             if (applog.isEnabled()) applog.appLog("[win] WM_DESTROY: calling PostQuitMessage(0)\n", .{});
             c.PostQuitMessage(0);
             return 0;


### PR DESCRIPTION
  ## Summary
                                                                                                                                                                                          
  Implement Neovim's `restart` and `connect` UI events with transparent
  reconnect on macOS, Linux, and Windows. Add an attach-only startup mode                                                                                                                 
  for joining an already-running nvim. Pre-attach failures now exit                                                                                                                       
  gracefully instead of leaving a blank window.                                                                                                                                           
                                                                                                                                                                                          
  ## Highlights                                                                                                                                                                           
                  
  ### CLI                                                                                                                                                                                 
   
  - `--connect-nvim=<addr>` / `--remote-ui=<addr>` (alias) — attach to a                                                                                                                  
    TCP `host:port`, Unix socket, or `\\.\pipe\nvim.*` (Windows). Connect
    failure exits with code 1.                                                                                                                                                            
                                                                                                                                                                                          
  ### UI events                                                                                                                                                                           
                                                                                                                                                                                          
  - `:restart` — core reconnects to the new listen address after the old                                                                                                                  
    channel closes; the GUI window stays alive. SSH / devcontainer / WSL
    modes fall back to re-spawn (the listen address is host-unreachable).                                                                                                                 
  - `:connect` — hot-swap to a different server. The previous nvim stays                                                                                                                  
    alive headless, so the spawned child is orphaned (skipping                                                                                                                            
    `child.wait()` which would otherwise block forever).                                                                                                                                  
                                                                                                                                                                                          
  ### C ABI                                                                                                                                                                               
                  
  - New `on_restart`, `on_connect`, `zonvie_core_start_connect`.                                                                                                                          
  - Leading `callbacks_size` field on `zonvie_callbacks` for backward
    compatibility.                                                                                                                                                                        
   
  ## Implementation notes                                                                                                                                                                 
                  
  - New `src/core/rpc_transport.zig`:                                                                                                                                                     
    - `parseListenAddr` recognizes TCP / Unix / Windows named pipe.
    - `Stream` tagged union wraps either `std.fs.File` or                                                                                                                                 
      `*WindowsOverlappedPipe`, so FrameReader / writerThreadFn /                                                                                                                         
      pumpStderr / sendStdinData are I/O-backend agnostic.                                                                                                                                
    - `WindowsOverlappedPipe` opens the pipe with `FILE_FLAG_OVERLAPPED`                                                                                                                  
      and uses `OVERLAPPED + GetOverlappedResult`. Without overlapped                                                                                                                     
      I/O, sync-mode HANDLEs serialize ReadFile/WriteFile at the kernel                                                                                                                   
      level and the writer thread deadlocks while FrameReader is                                                                                                                          
      blocked on read (POSIX sockets are unaffected).                                                                                                                                     
  - `runLoop` becomes outer-iterating; `restart_pending_addr` is                                                                                                                          
    consumed between iterations.                                                                                                                                                          
  - The inner read loop now breaks on a queued restart/connect — for
    local spawn the channel closes naturally, but on SSH the wrapper                                                                                                                      
    process never EOFs (the new nvim inherits stdio from the old one).                                                                                                                    
    Cleanup also kills the child on this path so `child.wait()` returns                                                                                                                   
    promptly and the re-spawn fallback kicks in.                                                                                                                                          
  - Pre-attach failure paths fire `on_exit` with code 1 instead of the                                                                                                                    
    previous `ui_attached_overall=true` guard.                                                                                                                                            
                                                                                                                                                                                          
  ## Testing                                                                                                                                                                              
                                                                                                                                                                                          
  | Platform | Scenarios |
  |---|---|
  | macOS | basic spawn, `:restart`, `:connect`, `--connect-nvim` startup, connect-failure exit, `:connect` orphan, SSH `:restart` |
  | Windows | basic spawn, `:restart` (overlapped pipe), connect-failure exit, window-close button, `:connect` orphan |                                                                   
  | Automated | `zig build test`, `zig build core`, `zig build windows -Dtarget=x86_64-windows-gnu`, macOS Xcode Debug |                                                                  
                                                                                                                                                                                          
  All scenarios pass.                                                                                                                                                                     
                                                                                                                                                                                          
  ## Known limitations

  - TCP `--connect-nvim` on Windows returns `UnsupportedOnWindows`                                                                                                                        
    (winsock SOCKET isn't interchangeable with a HANDLE for ReadFile/
    WriteFile). Named pipe is the only Windows-side entry point today.                                                                                                                    
  - Buffer state isn't preserved across `:restart` — standard Neovim
    behavior (the new nvim is a fresh process; only shada-tracked                                                                                                                         
    state survives).
