### PR TITLE
feat(tabline): AI-agent work-status indicator per tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ external = true
 style = "titlebar"  # "titlebar", "menu", or "sidebar"
 sidebar_position = "left"  # "left" or "right" (for sidebar style)
 sidebar_width = 200  # 100-500 (for sidebar style)
+agent_indicator = true  # show AI-agent status icon on terminal tabs
+agent_notification = true  # OS notification when an AI agent finishes
 
 [windows]
 external = false  # Each Neovim window as a separate OS window
@@ -297,6 +299,8 @@ Message routing rules are processed in order; first match wins.
 | `style` | Tabline style: "titlebar", "menu", or "sidebar" |
 | `sidebar_position` | Sidebar position: "left" or "right" (for sidebar style) |
 | `sidebar_width` | Sidebar width in pixels (100-500, for sidebar style) |
+| `agent_indicator` | Show AI-agent status icon on terminal tabs (true/false, default true) |
+| `agent_notification` | OS notification when an AI agent finishes (true/false, default true) |
 
 #### [windows]
 | Key | Description |

--- a/build.zig
+++ b/build.zig
@@ -181,6 +181,9 @@ pub fn build(b: *std.Build) !void {
 
         // --- Timer resolution for reducing scheduler quantum ---
         win_exe.linkSystemLibrary("winmm");
+
+        // --- AlphaBlend (color-emoji tab indicator composite) ---
+        win_exe.linkSystemLibrary("msimg32");
     }
 
     const install_win = b.addInstallArtifact(win_exe, .{

--- a/contrib/nvim/README.md
+++ b/contrib/nvim/README.md
@@ -1,0 +1,46 @@
+# zonvie AI-agent tab status
+
+Show whether an AI coding agent (Claude Code, Codex, …) running inside a Neovim
+`:terminal` is currently working, as a glyph on the zonvie ext_tabline tab.
+
+```
+┌──────────────┬──────────────────┬───────────┐
+│ ● term://claude │ term://codex   │ main.zig  │   ← ● = agent working
+└──────────────┴──────────────────┴───────────┘
+```
+
+## How it works
+
+The agent CLI sets its terminal's OSC window title. While thinking it animates a
+Braille spinner (`⠋⠙⠹…`, U+2800–U+28FF) as the leading glyph; when idle it shows
+a static marker (Claude: `✳`, Codex: bare title). `zonvie_agent_status.lua`
+captures the title via the `TermRequest` autocmd, classifies the first codepoint,
+and broadcasts `working`/`idle` per tabpage to zonvie with
+`vim.rpcnotify(0, "zonvie_agent_status", …)`. zonvie's core prefixes `● ` to the
+working tab's label (no agent-side configuration required).
+
+## Install
+
+**Nothing to install.** zonvie auto-injects this reporter into the Neovim it
+connects to (see `setupAgentStatus` in `src/core/rpc_session.zig`), so no
+user-side config is required. Just make the tabline visible and run an agent:
+
+```lua
+vim.opt.showtabline = 2 -- so the tabline (and glyph) is always visible
+```
+```
+:tabnew | terminal claude
+```
+
+> Do **not** add `require("zonvie_agent_status")` to your config — the module is
+> not on your runtimepath and that line errors with E5108. The standalone file
+> in this directory is only a readable reference / starting point if you want to
+> customize the detection and load it yourself.
+
+## Limitations
+
+- Only **working ↔ idle** is distinguishable from the OSC title. "Waiting for
+  user input" stops the spinner and is therefore reported as idle. Distinguishing
+  it would require agent-side hooks (Claude Code `Notification`/`Stop`), a
+  separate, opt-in mechanism.
+- The glyph is plain text on the tab label; it is not colored.

--- a/contrib/nvim/README.md
+++ b/contrib/nvim/README.md
@@ -5,7 +5,7 @@ Show whether an AI coding agent (Claude Code, Codex, …) running inside a Neovi
 
 ```
 ┌──────────────┬──────────────────┬───────────┐
-│ ● term://claude │ term://codex   │ main.zig  │   ← ● = agent working
+│ ✶ term://claude │ 🤖 term://codex │ main.zig  │   ← spinner = working, 🤖 = idle, ⏸ = waiting
 └──────────────┴──────────────────┴───────────┘
 ```
 
@@ -15,9 +15,11 @@ The agent CLI sets its terminal's OSC window title. While thinking it animates a
 Braille spinner (`⠋⠙⠹…`, U+2800–U+28FF) as the leading glyph; when idle it shows
 a static marker (Claude: `✳`, Codex: bare title). `zonvie_agent_status.lua`
 captures the title via the `TermRequest` autocmd, classifies the first codepoint,
-and broadcasts `working`/`idle` per tabpage to zonvie with
-`vim.rpcnotify(0, "zonvie_agent_status", …)`. zonvie's core prefixes `● ` to the
-working tab's label (no agent-side configuration required).
+and broadcasts a per-tabpage integer `state` to zonvie with
+`vim.rpcnotify(0, "zonvie_agent_status", { tab = <int>, state = <int>, title = <str> })`.
+zonvie's frontend owns the per-tab indicator glyph + spinner (no agent-side
+configuration required). State codes (see `include/zonvie_core.h`): `0`=none,
+`1`=idle, `2`=working/claude, `3`=working/braille, `4`=waiting for user input.
 
 ## Install
 
@@ -39,8 +41,11 @@ vim.opt.showtabline = 2 -- so the tabline (and glyph) is always visible
 
 ## Limitations
 
-- Only **working ↔ idle** is distinguishable from the OSC title. "Waiting for
-  user input" stops the spinner and is therefore reported as idle. Distinguishing
-  it would require agent-side hooks (Claude Code `Notification`/`Stop`), a
-  separate, opt-in mechanism.
+- The OSC title alone only exposes **working ↔ stopped** (the spinner stops for
+  both "done" and "waiting for input"). The auto-injected reporter tells the two
+  apart heuristically: ~0.8s after the spinner stops it scrapes the terminal tail
+  for pending-prompt strings (`Do you want`, `Enter to select`, `[y/n]`, …) and
+  reports `4`=waiting vs `1`=idle. The patterns are English-only and fragile by
+  nature, so a missed prompt simply falls back to idle. The minimal reference file
+  in this directory does **not** do this scrape and reports waiting as idle.
 - The glyph is plain text on the tab label; it is not colored.

--- a/contrib/nvim/zonvie_agent_status.lua
+++ b/contrib/nvim/zonvie_agent_status.lua
@@ -1,0 +1,76 @@
+-- zonvie AI-agent tab status reporter.
+--
+-- Shows whether an AI coding agent (Claude Code, Codex, ...) running inside a
+-- :terminal is currently working, as a glyph on the zonvie ext_tabline tab.
+--
+-- How it works (zero agent-side configuration):
+--   The agent CLI writes an OSC window title into its terminal. While the agent
+--   is thinking it animates a Braille spinner as the leading glyph; when idle it
+--   shows a static marker (Claude: U+2733, Codex: bare title). We classify the
+--   title's first codepoint and broadcast working/idle per tabpage to zonvie,
+--   which prefixes a "U+25CF" dot to the working tab's label.
+--
+-- Limitations:
+--   * Only working <-> idle is distinguishable via OSC. "Waiting for user input"
+--     looks identical to idle (the spinner stops), so it is reported as idle.
+--   * The tabline must be visible to see the glyph (e.g. `set showtabline=2`).
+--
+-- Install: place on your runtimepath and call:
+--   require("zonvie_agent_status").setup()
+local M = {}
+
+local last = {} -- tabpage handle -> last reported status ("working"/"idle")
+
+local function status_from_title(title)
+  if not title or title == "" then return "idle" end
+  local cp = vim.fn.char2nr(title) -- codepoint of the first character
+  -- Braille Patterns block: every agent CLI animates its spinner from here.
+  if cp >= 0x2800 and cp <= 0x28FF then return "working" end
+  return "idle"
+end
+
+local function tabs_for_buf(buf)
+  local out = {}
+  for _, t in ipairs(vim.api.nvim_list_tabpages()) do
+    for _, w in ipairs(vim.api.nvim_tabpage_list_wins(t)) do
+      if vim.api.nvim_win_get_buf(w) == buf then
+        out[#out + 1] = t
+        break
+      end
+    end
+  end
+  return out
+end
+
+local function report(tab, status, title)
+  if last[tab] == status then return end -- debounce spinner-frame churn
+  last[tab] = status
+  -- Broadcast to all RPC channels; zonvie's UI channel handles it.
+  vim.rpcnotify(0, "zonvie_agent_status", { tab = tab, status = status, title = title })
+end
+
+function M.setup()
+  vim.api.nvim_create_autocmd("TermRequest", {
+    callback = function(ev)
+      local seq = ev.data and ev.data.sequence or ""
+      -- Only OSC 0/1/2 (window/icon title) carry the spinner/idle marker.
+      local body = seq:match("^\27%]0;(.*)$")
+        or seq:match("^\27%]1;(.*)$")
+        or seq:match("^\27%]2;(.*)$")
+      if not body then return end
+      local status = status_from_title(body)
+      for _, tab in ipairs(tabs_for_buf(ev.buf)) do
+        report(tab, status, body)
+      end
+    end,
+  })
+  vim.api.nvim_create_autocmd("TermClose", {
+    callback = function(ev)
+      for _, tab in ipairs(tabs_for_buf(ev.buf)) do
+        report(tab, "idle", nil)
+      end
+    end,
+  })
+end
+
+return M

--- a/contrib/nvim/zonvie_agent_status.lua
+++ b/contrib/nvim/zonvie_agent_status.lua
@@ -7,26 +7,41 @@
 --   The agent CLI writes an OSC window title into its terminal. While the agent
 --   is thinking it animates a Braille spinner as the leading glyph; when idle it
 --   shows a static marker (Claude: U+2733, Codex: bare title). We classify the
---   title's first codepoint and broadcast working/idle per tabpage to zonvie,
---   which prefixes a "U+25CF" dot to the working tab's label.
+--   title's first codepoint and broadcast a per-tabpage `state` to zonvie, which
+--   owns the per-tab indicator glyph + spinner animation.
+--
+-- Payload contract (must match include/zonvie_core.h on_agent_status):
+--   vim.rpcnotify(0, 'zonvie_agent_status', { tab = <int>, state = <int>, title = <str> })
+--   state: 0=none, 1=idle (agent present, done), 2=working/claude,
+--          3=working/braille (codex & generic), 4=waiting for user input.
+--
+-- This is a readable, intentionally minimal reference. It reports only
+-- 0/1/3 (none / idle / working). The auto-injected reporter that ships in the
+-- zonvie core additionally distinguishes 2 (claude) and 4 (waiting for input).
 --
 -- Limitations:
---   * Only working <-> idle is distinguishable via OSC. "Waiting for user input"
---     looks identical to idle (the spinner stops), so it is reported as idle.
+--   * Working <-> idle is what OSC reliably exposes. "Waiting for user input"
+--     (state 4) looks identical to idle here (the spinner stops), so this
+--     reference reports it as idle.
 --   * The tabline must be visible to see the glyph (e.g. `set showtabline=2`).
 --
 -- Install: place on your runtimepath and call:
 --   require("zonvie_agent_status").setup()
 local M = {}
 
-local last = {} -- tabpage handle -> last reported status ("working"/"idle")
+-- state codes (see contract above)
+local STATE_NONE = 0
+local STATE_IDLE = 1
+local STATE_WORKING = 3
 
-local function status_from_title(title)
-  if not title or title == "" then return "idle" end
+local last = {} -- tabpage handle -> last reported state (integer)
+
+local function state_from_title(title)
+  if not title or title == "" then return STATE_IDLE end
   local cp = vim.fn.char2nr(title) -- codepoint of the first character
   -- Braille Patterns block: every agent CLI animates its spinner from here.
-  if cp >= 0x2800 and cp <= 0x28FF then return "working" end
-  return "idle"
+  if cp >= 0x2800 and cp <= 0x28FF then return STATE_WORKING end
+  return STATE_IDLE
 end
 
 local function tabs_for_buf(buf)
@@ -42,11 +57,11 @@ local function tabs_for_buf(buf)
   return out
 end
 
-local function report(tab, status, title)
-  if last[tab] == status then return end -- debounce spinner-frame churn
-  last[tab] = status
+local function report(tab, state, title)
+  if last[tab] == state then return end -- debounce spinner-frame churn
+  last[tab] = state
   -- Broadcast to all RPC channels; zonvie's UI channel handles it.
-  vim.rpcnotify(0, "zonvie_agent_status", { tab = tab, status = status, title = title })
+  vim.rpcnotify(0, "zonvie_agent_status", { tab = tab, state = state, title = title or "" })
 end
 
 function M.setup()
@@ -58,16 +73,16 @@ function M.setup()
         or seq:match("^\27%]1;(.*)$")
         or seq:match("^\27%]2;(.*)$")
       if not body then return end
-      local status = status_from_title(body)
+      local state = state_from_title(body)
       for _, tab in ipairs(tabs_for_buf(ev.buf)) do
-        report(tab, status, body)
+        report(tab, state, body)
       end
     end,
   })
   vim.api.nvim_create_autocmd("TermClose", {
     callback = function(ev)
       for _, tab in ipairs(tabs_for_buf(ev.buf)) do
-        report(tab, "idle", nil)
+        report(tab, STATE_NONE, nil)
       end
     end,
   })

--- a/include/zonvie_core.h
+++ b/include/zonvie_core.h
@@ -618,7 +618,7 @@ typedef void (*zonvie_on_tabline_hide_fn)(void* ctx);
    3=working/braille (codex & generic). The frontend renders/animates the
    per-tab indicator from this; fired immediately on change (not coupled to
    redraw, so a background-tab agent still updates). */
-typedef void (*zonvie_on_agent_status_fn)(void* ctx, int64_t tab_handle, uint8_t state);
+typedef void (*zonvie_on_agent_status_fn)(void* ctx, int64_t tab_handle, uint8_t state, const char* title, size_t title_len);
 
 /* --- Clipboard callbacks --- */
 

--- a/include/zonvie_core.h
+++ b/include/zonvie_core.h
@@ -614,10 +614,11 @@ typedef void (*zonvie_on_tabline_update_fn)(
 typedef void (*zonvie_on_tabline_hide_fn)(void* ctx);
 
 /* AI-agent work state for a tabpage (from the zonvie_agent_status RPC
-   notification). state: 0=none, 1=idle (agent present), 2=working/claude,
-   3=working/braille (codex & generic). The frontend renders/animates the
-   per-tab indicator from this; fired immediately on change (not coupled to
-   redraw, so a background-tab agent still updates). */
+   notification). state: 0=none, 1=idle (agent present, done), 2=working/claude,
+   3=working/braille (codex & generic), 4=waiting for user input (a decision
+   prompt is on screen). The frontend renders/animates the per-tab indicator
+   from this; fired immediately on change (not coupled to redraw, so a
+   background-tab agent still updates). */
 typedef void (*zonvie_on_agent_status_fn)(void* ctx, int64_t tab_handle, uint8_t state, const char* title, size_t title_len);
 
 /* --- Clipboard callbacks --- */

--- a/include/zonvie_core.h
+++ b/include/zonvie_core.h
@@ -1307,6 +1307,8 @@ typedef struct zonvie_config_values {
     const char* tabline_style;
     const char* tabline_sidebar_position;
     int32_t tabline_sidebar_width;
+    bool tabline_agent_indicator;
+    bool tabline_agent_notification;
     bool windows_external;
     // neovim
     const char* neovim_path;

--- a/include/zonvie_core.h
+++ b/include/zonvie_core.h
@@ -613,6 +613,13 @@ typedef void (*zonvie_on_tabline_update_fn)(
 /* Called when tabline should be hidden. */
 typedef void (*zonvie_on_tabline_hide_fn)(void* ctx);
 
+/* AI-agent work state for a tabpage (from the zonvie_agent_status RPC
+   notification). state: 0=none, 1=idle (agent present), 2=working/claude,
+   3=working/braille (codex & generic). The frontend renders/animates the
+   per-tab indicator from this; fired immediately on change (not coupled to
+   redraw, so a background-tab agent still updates). */
+typedef void (*zonvie_on_agent_status_fn)(void* ctx, int64_t tab_handle, uint8_t state);
+
 /* --- Clipboard callbacks --- */
 
 /* Called to get clipboard content.
@@ -768,6 +775,9 @@ typedef struct zonvie_callbacks {
     /* Connect UI event observer (informational; core handles reconnect).
        Appended after on_restart for the same ABI-compat reason. */
     zonvie_on_connect_fn on_connect;
+
+    /* AI-agent work state per tab. Appended at the end for ABI compat. */
+    zonvie_on_agent_status_fn on_agent_status;
 } zonvie_callbacks;
 
 void zonvie_core_set_log_enabled(zonvie_core *core, int enabled);

--- a/macos/Sources/App/Config.swift
+++ b/macos/Sources/App/Config.swift
@@ -110,6 +110,8 @@ struct ZonvieConfig {
         var style: String = "titlebar"       // "titlebar", "menu", "sidebar"
         var sidebarPosition: String = "left" // "left" or "right"
         var sidebarWidth: Int = 200          // 100-500 pixels
+        var agentIndicator: Bool = true      // per-tab AI-agent status icon
+        var agentNotification: Bool = true   // OS notification on agent completion
     }
 
     struct WindowsConfig {
@@ -266,6 +268,8 @@ struct ZonvieConfig {
         if let s = v.tabline_style { config.tabline.style = String(cString: s) }
         if let s = v.tabline_sidebar_position { config.tabline.sidebarPosition = String(cString: s) }
         config.tabline.sidebarWidth = Int(v.tabline_sidebar_width)
+        config.tabline.agentIndicator = v.tabline_agent_indicator
+        config.tabline.agentNotification = v.tabline_agent_notification
         config.windows.external = v.windows_external
 
         // Neovim

--- a/macos/Sources/App/ViewController.swift
+++ b/macos/Sources/App/ViewController.swift
@@ -13,6 +13,7 @@ final class ViewController: NSViewController {
     // Notification observers for tabline
     private var tablineUpdateObserver: Any?
     private var tablineHideObserver: Any?
+    private var agentStatusObserver: Any?
 
     // Current tab list for lookup
     private var currentTabs: [(handle: Int64, name: String)] = []
@@ -235,6 +236,16 @@ final class ViewController: NSViewController {
             queue: .main
         ) { [weak self] _ in
             self?.handleTablineHide()
+        }
+
+        agentStatusObserver = NotificationCenter.default.addObserver(
+            forName: ZonvieCore.agentStatusNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let info = notification.object as? ZonvieCore.AgentStatusInfo else { return }
+            self?.tabBarView?.setAgentState(handle: info.tabHandle, state: info.state)
+            self?.sidebarView?.setAgentState(handle: info.tabHandle, state: info.state)
         }
     }
 

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -7056,13 +7056,12 @@ final class ZonvieCore {
 
             // Indicator rendering is driven by this notification; skip it (no icon)
             // when the indicator is disabled. State is still tracked above so the
-            // completion notification keeps working independently. The waiting
-            // state (4) renders like idle (the robot icon) for now.
+            // completion notification keeps working independently. State 4 (waiting)
+            // renders a distinct pause glyph in the views.
             if ZonvieConfig.shared.tabline.agentIndicator {
-                let viewState: UInt8 = (state == 4) ? 1 : state
                 NotificationCenter.default.post(
                     name: ZonvieCore.agentStatusNotification,
-                    object: ZonvieCore.AgentStatusInfo(tabHandle: tabHandle, state: viewState)
+                    object: ZonvieCore.AgentStatusInfo(tabHandle: tabHandle, state: state)
                 )
             }
         }

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -7031,7 +7031,8 @@ final class ZonvieCore {
             // zonvie's own :terminal, so the app is effectively always frontmost
             // and suppression would silence every notification. Include the tab
             // name to identify which agent finished.
-            if (prev == 2 || prev == 3) && state == 1 {
+            if ZonvieConfig.shared.tabline.agentNotification,
+               (prev == 2 || prev == 3) && state == 1 {
                 // Prefer the agent's own title/summary (e.g. Claude's task topic);
                 // fall back to the tab name basename.
                 let summary: String
@@ -7045,10 +7046,15 @@ final class ZonvieCore {
                 self.showOSNotification(title: "Zonvie", body: body)
             }
 
-            NotificationCenter.default.post(
-                name: ZonvieCore.agentStatusNotification,
-                object: ZonvieCore.AgentStatusInfo(tabHandle: tabHandle, state: state)
-            )
+            // Indicator rendering is driven by this notification; skip it (no icon)
+            // when the indicator is disabled. State is still tracked above so the
+            // completion notification keeps working independently.
+            if ZonvieConfig.shared.tabline.agentIndicator {
+                NotificationCenter.default.post(
+                    name: ZonvieCore.agentStatusNotification,
+                    object: ZonvieCore.AgentStatusInfo(tabHandle: tabHandle, state: state)
+                )
+            }
         }
     }
 

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -917,10 +917,16 @@ final class ZonvieCore {
                 }
                 core.handleConnectEvent(serverAddr: addr)
             },
-            on_agent_status: { ctx, tabHandle, state in
+            on_agent_status: { ctx, tabHandle, state, titlePtr, titleLen in
                 guard let ctx else { return }
                 let me = Unmanaged<ZonvieCore>.fromOpaque(ctx).takeUnretainedValue()
-                me.onAgentStatus(tabHandle: tabHandle, state: state)
+                let title: String
+                if let p = titlePtr, titleLen > 0 {
+                    title = String(decoding: UnsafeRawBufferPointer(start: p, count: titleLen), as: UTF8.self)
+                } else {
+                    title = ""
+                }
+                me.onAgentStatus(tabHandle: tabHandle, state: state, title: title)
             }
         )
 
@@ -6985,7 +6991,8 @@ final class ZonvieCore {
         // Dispatch to main thread via NotificationCenter.
         // Pass data as notification.object (reference type) to avoid Obj-C
         // bridging issues with named tuples in NSDictionary-backed userInfo.
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            self?.agentTabNames = Dictionary(parsedTabs.map { ($0.handle, $0.name) }, uniquingKeysWith: { a, _ in a })
             NotificationCenter.default.post(
                 name: ZonvieCore.tablineUpdateNotification,
                 object: TablineUpdateInfo(tabs: parsedTabs, currentTab: curtab)
@@ -7004,8 +7011,40 @@ final class ZonvieCore {
     }
 
     // Fired on the core RPC thread when a tab's AI-agent state changes.
-    nonisolated private func onAgentStatus(tabHandle: Int64, state: UInt8) {
-        DispatchQueue.main.async {
+    // Main-thread-only: previous agent state and last-known name per tab handle,
+    // used to fire a per-tab "finished" notification on a working(2/3)->idle(1)
+    // transition (the name map is refreshed from onTablineUpdate).
+    private var agentPrevStates: [Int64: UInt8] = [:]
+    private var agentTabNames: [Int64: String] = [:]
+
+    nonisolated private func onAgentStatus(tabHandle: Int64, state: UInt8, title: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let prev = self.agentPrevStates[tabHandle] ?? 0
+            if state == 0 {
+                self.agentPrevStates.removeValue(forKey: tabHandle)
+            } else {
+                self.agentPrevStates[tabHandle] = state
+            }
+            // Completion = work just finished -> always notify. Window-level
+            // focus suppression doesn't fit this app: the agent runs inside
+            // zonvie's own :terminal, so the app is effectively always frontmost
+            // and suppression would silence every notification. Include the tab
+            // name to identify which agent finished.
+            if (prev == 2 || prev == 3) && state == 1 {
+                // Prefer the agent's own title/summary (e.g. Claude's task topic);
+                // fall back to the tab name basename.
+                let summary: String
+                if !title.isEmpty {
+                    summary = title
+                } else {
+                    let raw = self.agentTabNames[tabHandle] ?? ""
+                    summary = raw.isEmpty ? "" : (raw as NSString).lastPathComponent
+                }
+                let body = summary.isEmpty ? "AI agent finished" : "Finished: \(summary)"
+                self.showOSNotification(title: "Zonvie", body: body)
+            }
+
             NotificationCenter.default.post(
                 name: ZonvieCore.agentStatusNotification,
                 object: ZonvieCore.AgentStatusInfo(tabHandle: tabHandle, state: state)

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -916,6 +916,11 @@ final class ZonvieCore {
                     addr = ""
                 }
                 core.handleConnectEvent(serverAddr: addr)
+            },
+            on_agent_status: { ctx, tabHandle, state in
+                guard let ctx else { return }
+                let me = Unmanaged<ZonvieCore>.fromOpaque(ctx).takeUnretainedValue()
+                me.onAgentStatus(tabHandle: tabHandle, state: state)
             }
         )
 
@@ -6998,6 +7003,16 @@ final class ZonvieCore {
         }
     }
 
+    // Fired on the core RPC thread when a tab's AI-agent state changes.
+    nonisolated private func onAgentStatus(tabHandle: Int64, state: UInt8) {
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: ZonvieCore.agentStatusNotification,
+                object: ZonvieCore.AgentStatusInfo(tabHandle: tabHandle, state: state)
+            )
+        }
+    }
+
     // MARK: - Grid scroll callback
 
     nonisolated private func onGridScroll(gridId: Int64) {
@@ -7064,6 +7079,19 @@ final class ZonvieCore {
             self.currentTab = currentTab
         }
     }
+
+    /// Container for an AI-agent status update passed via NSNotification.object.
+    final class AgentStatusInfo {
+        let tabHandle: Int64
+        let state: UInt8  // 0=none, 1=idle, 2=working/claude, 3=working/braille
+        init(tabHandle: Int64, state: UInt8) {
+            self.tabHandle = tabHandle
+            self.state = state
+        }
+    }
+
+    /// Notification name for AI-agent tab status
+    static let agentStatusNotification = NSNotification.Name("ZonvieAgentStatus")
 
     /// Notification name for tabline update
     static let tablineUpdateNotification = NSNotification.Name("ZonvieTablineUpdate")

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -7031,10 +7031,13 @@ final class ZonvieCore {
             // zonvie's own :terminal, so the app is effectively always frontmost
             // and suppression would silence every notification. Include the tab
             // name to identify which agent finished.
+            // A working(2/3) -> idle(1) transition means the agent finished;
+            // working -> waiting(4) means it paused for a decision/input. Notify
+            // with a distinct message for each (done vs needs-action). done-vs-
+            // error can't be told apart from an interactive terminal, so both
+            // land here as "finished".
             if ZonvieConfig.shared.tabline.agentNotification,
-               (prev == 2 || prev == 3) && state == 1 {
-                // Prefer the agent's own title/summary (e.g. Claude's task topic);
-                // fall back to the tab name basename.
+               (prev == 2 || prev == 3), (state == 1 || state == 4) {
                 let summary: String
                 if !title.isEmpty {
                     summary = title
@@ -7042,17 +7045,24 @@ final class ZonvieCore {
                     let raw = self.agentTabNames[tabHandle] ?? ""
                     summary = raw.isEmpty ? "" : (raw as NSString).lastPathComponent
                 }
-                let body = summary.isEmpty ? "AI agent finished" : "Finished: \(summary)"
+                let body: String
+                if state == 4 {
+                    body = summary.isEmpty ? "AI agent needs input" : "Needs input: \(summary)"
+                } else {
+                    body = summary.isEmpty ? "AI agent finished" : "Finished: \(summary)"
+                }
                 self.showOSNotification(title: "Zonvie", body: body)
             }
 
             // Indicator rendering is driven by this notification; skip it (no icon)
             // when the indicator is disabled. State is still tracked above so the
-            // completion notification keeps working independently.
+            // completion notification keeps working independently. The waiting
+            // state (4) renders like idle (the robot icon) for now.
             if ZonvieConfig.shared.tabline.agentIndicator {
+                let viewState: UInt8 = (state == 4) ? 1 : state
                 NotificationCenter.default.post(
                     name: ZonvieCore.agentStatusNotification,
-                    object: ZonvieCore.AgentStatusInfo(tabHandle: tabHandle, state: state)
+                    object: ZonvieCore.AgentStatusInfo(tabHandle: tabHandle, state: viewState)
                 )
             }
         }

--- a/macos/Sources/UI/TabBarView.swift
+++ b/macos/Sources/UI/TabBarView.swift
@@ -226,7 +226,7 @@ final class TabBarView: NSView {
             floatPath.stroke()
 
             // Draw tab name
-            let displayName = tab.name.isEmpty ? "[No Name]" : (tab.name as NSString).lastPathComponent
+            let displayName = agentPrefix(forHandle: tab.handle) + Self.baseLabel(tab.name)
             let font = NSFont.systemFont(ofSize: 12, weight: .medium)
             let attributes: [NSAttributedString.Key: Any] = [
                 .foregroundColor: NSColor.labelColor,
@@ -241,6 +241,51 @@ final class TabBarView: NSView {
             displayName.draw(in: textRect, withAttributes: attributes)
         }
     }
+
+    // AI-agent indicator, set via on_agent_status. Per-tab state:
+    // 1=idle (agent present)→🤖, 2=working/claude→star spinner, 3=working/braille (codex).
+    private var agentStates: [Int64: UInt8] = [:]
+    private var spinnerFrame = 0
+    private var spinnerTimer: Timer?
+
+    // Claude Code's official thinking-icon sequence (120ms/frame), per the
+    // reverse-engineered default frames: · ✢ ✳ ✶ ✻ ✽.
+    static let claudeFrames = ["·", "✢", "✳", "✶", "✻", "✽"]
+    // Standard Braille spinner — Codex (and generic agents) animate this.
+    static let brailleFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+    /// Beautified tab label (basename of the term:// or file path).
+    static func baseLabel(_ name: String) -> String {
+        return name.isEmpty ? "[No Name]" : (name as NSString).lastPathComponent
+    }
+
+    /// Update one tab's agent state; drives the animation timer + repaint.
+    func setAgentState(handle: Int64, state: UInt8) {
+        if state == 0 { agentStates.removeValue(forKey: handle) } else { agentStates[handle] = state }
+        let anyWorking = agentStates.values.contains { $0 == 2 || $0 == 3 }
+        if anyWorking, spinnerTimer == nil {
+            spinnerTimer = Timer.scheduledTimer(withTimeInterval: 0.12, repeats: true) { [weak self] _ in
+                self?.spinnerFrame &+= 1
+                self?.needsDisplay = true
+            }
+        } else if !anyWorking, let t = spinnerTimer {
+            t.invalidate()
+            spinnerTimer = nil
+        }
+        needsDisplay = true
+    }
+
+    /// Leading agent glyph (with trailing space) for a tab, or "" if none.
+    func agentPrefix(forHandle handle: Int64) -> String {
+        switch agentStates[handle] {
+        case 1: return "🤖 "
+        case 2: return Self.claudeFrames[spinnerFrame % Self.claudeFrames.count] + " "
+        case 3: return Self.brailleFrames[spinnerFrame % Self.brailleFrames.count] + " "
+        default: return ""
+        }
+    }
+
+    deinit { spinnerTimer?.invalidate() }
 
     // Tab border color for subtle shadow effect
     private var tabBorderColor: NSColor {
@@ -293,7 +338,7 @@ final class TabBarView: NSView {
             .paragraphStyle: paragraphStyle
         ]
 
-        let displayName = tab.name.isEmpty ? "[No Name]" : (tab.name as NSString).lastPathComponent
+        let displayName = agentPrefix(forHandle: tab.handle) + Self.baseLabel(tab.name)
         displayName.draw(in: titleRect, withAttributes: attributes)
 
         // Close button (X) - show on selected or hovered tabs

--- a/macos/Sources/UI/TabBarView.swift
+++ b/macos/Sources/UI/TabBarView.swift
@@ -226,7 +226,6 @@ final class TabBarView: NSView {
             floatPath.stroke()
 
             // Draw tab name
-            let displayName = agentPrefix(forHandle: tab.handle) + Self.baseLabel(tab.name)
             let font = NSFont.systemFont(ofSize: 12, weight: .medium)
             let attributes: [NSAttributedString.Key: Any] = [
                 .foregroundColor: NSColor.labelColor,
@@ -238,7 +237,10 @@ final class TabBarView: NSView {
                 width: tabWidth - tabPadding * 2,
                 height: 16
             )
-            displayName.draw(in: textRect, withAttributes: attributes)
+            let indicatorW = drawAgentIndicator(forHandle: tab.handle, in: textRect, font: font, color: NSColor.labelColor)
+            let labelRect = NSRect(x: textRect.minX + indicatorW, y: textRect.minY,
+                                   width: textRect.width - indicatorW, height: textRect.height)
+            Self.baseLabel(tab.name).draw(in: labelRect, withAttributes: attributes)
         }
     }
 
@@ -275,14 +277,33 @@ final class TabBarView: NSView {
         needsDisplay = true
     }
 
-    /// Leading agent glyph (with trailing space) for a tab, or "" if none.
-    func agentPrefix(forHandle handle: Int64) -> String {
+    // Fixed width reserved for the agent indicator, so that varying spinner
+    // glyph widths don't shift the tab title left/right between frames.
+    static let agentIndicatorWidth: CGFloat = 18
+
+    /// Single agent indicator glyph for a tab (no trailing space), or nil.
+    func agentGlyph(forHandle handle: Int64) -> String? {
         switch agentStates[handle] {
-        case 1: return "🤖 "
-        case 2: return Self.claudeFrames[spinnerFrame % Self.claudeFrames.count] + " "
-        case 3: return Self.brailleFrames[spinnerFrame % Self.brailleFrames.count] + " "
-        default: return ""
+        case 1: return "🤖"
+        case 2: return Self.claudeFrames[spinnerFrame % Self.claudeFrames.count]
+        case 3: return Self.brailleFrames[spinnerFrame % Self.brailleFrames.count]
+        default: return nil
         }
+    }
+
+    /// Draw the agent indicator centered in a fixed-width box at the left edge
+    /// of `rect`, and return the x-offset the title should start at (0 if none).
+    /// Centering in a fixed box keeps the title anchored across spinner frames.
+    func drawAgentIndicator(forHandle handle: Int64, in rect: NSRect, font: NSFont, color: NSColor) -> CGFloat {
+        guard let glyph = agentGlyph(forHandle: handle) else { return 0 }
+        let para = NSMutableParagraphStyle()
+        para.alignment = .center
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font, .foregroundColor: color, .paragraphStyle: para,
+        ]
+        let box = NSRect(x: rect.minX, y: rect.minY, width: Self.agentIndicatorWidth, height: rect.height)
+        glyph.draw(in: box, withAttributes: attrs)
+        return Self.agentIndicatorWidth
     }
 
     deinit { spinnerTimer?.invalidate() }
@@ -338,8 +359,10 @@ final class TabBarView: NSView {
             .paragraphStyle: paragraphStyle
         ]
 
-        let displayName = agentPrefix(forHandle: tab.handle) + Self.baseLabel(tab.name)
-        displayName.draw(in: titleRect, withAttributes: attributes)
+        let indicatorW = drawAgentIndicator(forHandle: tab.handle, in: titleRect, font: font, color: textColor)
+        let labelRect = NSRect(x: titleRect.minX + indicatorW, y: titleRect.minY,
+                               width: titleRect.width - indicatorW, height: titleRect.height)
+        Self.baseLabel(tab.name).draw(in: labelRect, withAttributes: attributes)
 
         // Close button (X) - show on selected or hovered tabs
         if isSelected || isHovered {

--- a/macos/Sources/UI/TabBarView.swift
+++ b/macos/Sources/UI/TabBarView.swift
@@ -245,7 +245,7 @@ final class TabBarView: NSView {
     }
 
     // AI-agent indicator, set via on_agent_status. Per-tab state:
-    // 1=idle (agent present)→🤖, 2=working/claude→star spinner, 3=working/braille (codex).
+    // 1=idle→🤖, 2=working/claude→star spinner, 3=working/braille (codex), 4=waiting→⏸️.
     private var agentStates: [Int64: UInt8] = [:]
     private var spinnerFrame = 0
     private var spinnerTimer: Timer?
@@ -287,6 +287,7 @@ final class TabBarView: NSView {
         case 1: return "🤖"
         case 2: return Self.claudeFrames[spinnerFrame % Self.claudeFrames.count]
         case 3: return Self.brailleFrames[spinnerFrame % Self.brailleFrames.count]
+        case 4: return "⏸️"
         default: return nil
         }
     }

--- a/macos/Sources/UI/TabMenuManager.swift
+++ b/macos/Sources/UI/TabMenuManager.swift
@@ -69,7 +69,7 @@ final class TabMenuManager {
 
         // Add tab items
         for (index, tab) in tabs.enumerated() {
-            let displayName = tab.name.isEmpty ? "[No Name]" : (tab.name as NSString).lastPathComponent
+            let displayName = TabBarView.baseLabel(tab.name)
             let item = NSMenuItem(title: displayName, action: #selector(handleSelectTab(_:)), keyEquivalent: "")
             item.target = self
             item.tag = index

--- a/macos/Sources/UI/TabSidebarView.swift
+++ b/macos/Sources/UI/TabSidebarView.swift
@@ -41,6 +41,7 @@ final class TabSidebarView: NSView {
         case 1: return "🤖"
         case 2: return TabBarView.claudeFrames[spinnerFrame % TabBarView.claudeFrames.count]
         case 3: return TabBarView.brailleFrames[spinnerFrame % TabBarView.brailleFrames.count]
+        case 4: return "⏸️"
         default: return nil
         }
     }

--- a/macos/Sources/UI/TabSidebarView.swift
+++ b/macos/Sources/UI/TabSidebarView.swift
@@ -35,13 +35,29 @@ final class TabSidebarView: NSView {
         needsDisplay = true
     }
 
-    private func agentPrefix(forHandle handle: Int64) -> String {
+    /// Single agent indicator glyph for a tab (no trailing space), or nil.
+    private func agentGlyph(forHandle handle: Int64) -> String? {
         switch agentStates[handle] {
-        case 1: return "🤖 "
-        case 2: return TabBarView.claudeFrames[spinnerFrame % TabBarView.claudeFrames.count] + " "
-        case 3: return TabBarView.brailleFrames[spinnerFrame % TabBarView.brailleFrames.count] + " "
-        default: return ""
+        case 1: return "🤖"
+        case 2: return TabBarView.claudeFrames[spinnerFrame % TabBarView.claudeFrames.count]
+        case 3: return TabBarView.brailleFrames[spinnerFrame % TabBarView.brailleFrames.count]
+        default: return nil
         }
+    }
+
+    /// Draw the agent indicator centered in a fixed-width box at the left edge
+    /// of `rect`, and return the x-offset the title should start at (0 if none).
+    /// Centering in a fixed box keeps the title anchored across spinner frames.
+    private func drawAgentIndicator(forHandle handle: Int64, in rect: NSRect, font: NSFont, color: NSColor) -> CGFloat {
+        guard let glyph = agentGlyph(forHandle: handle) else { return 0 }
+        let para = NSMutableParagraphStyle()
+        para.alignment = .center
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font, .foregroundColor: color, .paragraphStyle: para,
+        ]
+        let box = NSRect(x: rect.minX, y: rect.minY, width: TabBarView.agentIndicatorWidth, height: rect.height)
+        glyph.draw(in: box, withAttributes: attrs)
+        return TabBarView.agentIndicatorWidth
     }
 
     private var hoveredTabIndex: Int? = nil
@@ -321,7 +337,6 @@ final class TabSidebarView: NSView {
 
             // Draw tab name in floating row
             let tab = tabs[dragIdx]
-            let displayName = agentPrefix(forHandle: tab.handle) + TabBarView.baseLabel(tab.name)
             let font = NSFont.systemFont(ofSize: 12, weight: .medium)
             let paragraphStyle = NSMutableParagraphStyle()
             paragraphStyle.lineBreakMode = .byTruncatingTail
@@ -336,7 +351,10 @@ final class TabSidebarView: NSView {
                 width: floatRect.width - tabPadding * 2,
                 height: 16
             )
-            displayName.draw(in: textRect, withAttributes: attributes)
+            let indicatorW = drawAgentIndicator(forHandle: tab.handle, in: textRect, font: font, color: tabTextSelectedColor)
+            let labelRect = NSRect(x: textRect.minX + indicatorW, y: textRect.minY,
+                                   width: textRect.width - indicatorW, height: textRect.height)
+            TabBarView.baseLabel(tab.name).draw(in: labelRect, withAttributes: attributes)
         }
     }
 
@@ -368,7 +386,6 @@ final class TabSidebarView: NSView {
         }
 
         // Tab name
-        let displayName = agentPrefix(forHandle: tab.handle) + TabBarView.baseLabel(tab.name)
         let textColor = isSelected ? tabTextSelectedColor : tabTextColor
         let font = NSFont.systemFont(ofSize: 12, weight: isSelected ? .medium : .regular)
 
@@ -389,7 +406,10 @@ final class TabSidebarView: NSView {
             .font: font,
             .paragraphStyle: paragraphStyle
         ]
-        displayName.draw(in: textRect, withAttributes: attributes)
+        let indicatorW = drawAgentIndicator(forHandle: tab.handle, in: textRect, font: font, color: textColor)
+        let labelRect = NSRect(x: textRect.minX + indicatorW, y: textRect.minY,
+                               width: textRect.width - indicatorW, height: textRect.height)
+        TabBarView.baseLabel(tab.name).draw(in: labelRect, withAttributes: attributes)
 
         // Close button (X) on hover or selected
         if isSelected || isHovered {

--- a/macos/Sources/UI/TabSidebarView.swift
+++ b/macos/Sources/UI/TabSidebarView.swift
@@ -13,6 +13,37 @@ final class TabSidebarView: NSView {
 
     private var tabs: [Tab] = []
     private var currentTab: Int64 = 0
+
+    // AI-agent indicator (set via on_agent_status). Reuses TabBarView's glyph
+    // frame sets / baseLabel; 1=idle→🤖, 2=working/claude, 3=working/braille.
+    private var agentStates: [Int64: UInt8] = [:]
+    private var spinnerFrame = 0
+    private var spinnerTimer: Timer?
+
+    func setAgentState(handle: Int64, state: UInt8) {
+        if state == 0 { agentStates.removeValue(forKey: handle) } else { agentStates[handle] = state }
+        let anyWorking = agentStates.values.contains { $0 == 2 || $0 == 3 }
+        if anyWorking, spinnerTimer == nil {
+            spinnerTimer = Timer.scheduledTimer(withTimeInterval: 0.12, repeats: true) { [weak self] _ in
+                self?.spinnerFrame &+= 1
+                self?.needsDisplay = true
+            }
+        } else if !anyWorking, let t = spinnerTimer {
+            t.invalidate()
+            spinnerTimer = nil
+        }
+        needsDisplay = true
+    }
+
+    private func agentPrefix(forHandle handle: Int64) -> String {
+        switch agentStates[handle] {
+        case 1: return "🤖 "
+        case 2: return TabBarView.claudeFrames[spinnerFrame % TabBarView.claudeFrames.count] + " "
+        case 3: return TabBarView.brailleFrames[spinnerFrame % TabBarView.brailleFrames.count] + " "
+        default: return ""
+        }
+    }
+
     private var hoveredTabIndex: Int? = nil
     private var hoveredCloseButton: Int? = nil
     private var hoveredNewTabButton: Bool = false
@@ -191,6 +222,7 @@ final class TabSidebarView: NSView {
         if let observer = colorschemeObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        spinnerTimer?.invalidate()
     }
 
     private func observeColorschemeChanges() {
@@ -289,7 +321,7 @@ final class TabSidebarView: NSView {
 
             // Draw tab name in floating row
             let tab = tabs[dragIdx]
-            let displayName = tab.name.isEmpty ? "[No Name]" : (tab.name as NSString).lastPathComponent
+            let displayName = agentPrefix(forHandle: tab.handle) + TabBarView.baseLabel(tab.name)
             let font = NSFont.systemFont(ofSize: 12, weight: .medium)
             let paragraphStyle = NSMutableParagraphStyle()
             paragraphStyle.lineBreakMode = .byTruncatingTail
@@ -336,7 +368,7 @@ final class TabSidebarView: NSView {
         }
 
         // Tab name
-        let displayName = tab.name.isEmpty ? "[No Name]" : (tab.name as NSString).lastPathComponent
+        let displayName = agentPrefix(forHandle: tab.handle) + TabBarView.baseLabel(tab.name)
         let textColor = isSelected ? tabTextSelectedColor : tabTextColor
         let font = NSFont.systemFont(ofSize: 12, weight: isSelected ? .medium : .regular)
 

--- a/src/core/c_api.zig
+++ b/src/core/c_api.zig
@@ -525,6 +525,11 @@ pub const Callbacks = extern struct {
     // that don't fill this field get a null callback and lose the
     // notification — the reconnect itself still happens transparently.
     on_connect: ?*const fn (ctx: ?*anyopaque, server_addr: [*]const u8, server_addr_len: usize) callconv(.c) void = null,
+
+    // AI-agent work status per tab. Appended at the end for ABI compat (see
+    // on_restart note). state: 0=none, 1=idle (agent present), 2=working/claude,
+    // 3=working/braille (codex & generic).
+    on_agent_status: ?*const fn (ctx: ?*anyopaque, tab_handle: i64, state: u8) callconv(.c) void = null,
 };
 
 
@@ -628,6 +633,7 @@ pub export fn zonvie_core_create(cb: ?*const Callbacks, callbacks_size: usize, c
         // ext_tabline callbacks
         .on_tabline_update = box.cb.on_tabline_update,
         .on_tabline_hide = box.cb.on_tabline_hide,
+        .on_agent_status = box.cb.on_agent_status,
 
         // Grid scroll notification
         .on_grid_scroll = box.cb.on_grid_scroll,

--- a/src/core/c_api.zig
+++ b/src/core/c_api.zig
@@ -529,7 +529,7 @@ pub const Callbacks = extern struct {
     // AI-agent work status per tab. Appended at the end for ABI compat (see
     // on_restart note). state: 0=none, 1=idle (agent present), 2=working/claude,
     // 3=working/braille (codex & generic).
-    on_agent_status: ?*const fn (ctx: ?*anyopaque, tab_handle: i64, state: u8) callconv(.c) void = null,
+    on_agent_status: ?*const fn (ctx: ?*anyopaque, tab_handle: i64, state: u8, title: [*]const u8, title_len: usize) callconv(.c) void = null,
 };
 
 

--- a/src/core/c_api.zig
+++ b/src/core/c_api.zig
@@ -527,8 +527,9 @@ pub const Callbacks = extern struct {
     on_connect: ?*const fn (ctx: ?*anyopaque, server_addr: [*]const u8, server_addr_len: usize) callconv(.c) void = null,
 
     // AI-agent work status per tab. Appended at the end for ABI compat (see
-    // on_restart note). state: 0=none, 1=idle (agent present), 2=working/claude,
-    // 3=working/braille (codex & generic).
+    // on_restart note). state: 0=none, 1=idle (agent present, done),
+    // 2=working/claude, 3=working/braille (codex & generic),
+    // 4=waiting for user input (a decision prompt is on screen).
     on_agent_status: ?*const fn (ctx: ?*anyopaque, tab_handle: i64, state: u8, title: [*]const u8, title_len: usize) callconv(.c) void = null,
 };
 

--- a/src/core/c_api.zig
+++ b/src/core/c_api.zig
@@ -1522,6 +1522,8 @@ pub const zonvie_config_values = extern struct {
     tabline_style: [*:0]const u8 = "titlebar",
     tabline_sidebar_position: [*:0]const u8 = "left",
     tabline_sidebar_width: i32 = 200,
+    tabline_agent_indicator: bool = true,
+    tabline_agent_notification: bool = true,
     windows_external: bool = false,
     // neovim
     neovim_path: [*:0]const u8 = "nvim",
@@ -1633,6 +1635,8 @@ fn buildConfigValues(alloc: std.mem.Allocator, cfg: *const config.Config) zonvie
         .tabline_style = dupeZForC(alloc, cfg.tabline.style, "titlebar"),
         .tabline_sidebar_position = dupeZForC(alloc, cfg.tabline.sidebar_position, "left"),
         .tabline_sidebar_width = @intCast(cfg.tabline.sidebar_width),
+        .tabline_agent_indicator = cfg.tabline.agent_indicator,
+        .tabline_agent_notification = cfg.tabline.agent_notification,
         .windows_external = cfg.windows.external,
         // neovim
         .neovim_path = dupeZForC(alloc, cfg.neovim.path, "nvim"),

--- a/src/core/config.zig
+++ b/src/core/config.zig
@@ -263,6 +263,9 @@ pub const Config = struct {
         style: []const u8 = "titlebar",
         sidebar_position: []const u8 = "left",
         sidebar_width: u32 = 200,
+        // AI-agent status: per-tab indicator icon and completion OS notification.
+        agent_indicator: bool = true,
+        agent_notification: bool = true,
     };
 
     pub const WindowsConfig = struct {
@@ -507,6 +510,8 @@ pub const Config = struct {
                 }
             }
             if (t.sidebar_width) |w| self.tabline.sidebar_width = @max(100, @min(500, w));
+            if (t.agent_indicator) |b| self.tabline.agent_indicator = b;
+            if (t.agent_notification) |b| self.tabline.agent_notification = b;
         }
 
         if (cfg.windows) |w| {
@@ -842,6 +847,8 @@ const TomlTabline = struct {
     style: ?[]const u8 = null,
     sidebar_position: ?[]const u8 = null,
     sidebar_width: ?u32 = null,
+    agent_indicator: ?bool = null,
+    agent_notification: ?bool = null,
 };
 
 const TomlWindows = struct {

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -246,6 +246,13 @@ pub const Callbacks = struct {
     /// Called when tabline should be hidden.
     on_tabline_hide: ?*const fn (ctx: ?*anyopaque) callconv(.c) void = null,
 
+    /// AI-agent work status for a tabpage (from the zonvie_agent_status RPC
+    /// notification). state: 0=none, 1=idle (agent present), 2=working/claude,
+    /// 3=working/braille (codex & generic). The frontend renders/animates the
+    /// per-tab indicator from this; fired immediately on change (not coupled to
+    /// redraw, so a background-tab agent still updates).
+    on_agent_status: ?*const fn (ctx: ?*anyopaque, tab_handle: i64, state: u8) callconv(.c) void = null,
+
     /// Called when a grid receives a grid_scroll event.
     /// Frontend should clear pixel-based smooth scroll offset for this grid.
     on_grid_scroll: ?*const fn (ctx: ?*anyopaque, grid_id: i64) callconv(.c) void = null,

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -251,7 +251,7 @@ pub const Callbacks = struct {
     /// 3=working/braille (codex & generic). The frontend renders/animates the
     /// per-tab indicator from this; fired immediately on change (not coupled to
     /// redraw, so a background-tab agent still updates).
-    on_agent_status: ?*const fn (ctx: ?*anyopaque, tab_handle: i64, state: u8) callconv(.c) void = null,
+    on_agent_status: ?*const fn (ctx: ?*anyopaque, tab_handle: i64, state: u8, title: [*]const u8, title_len: usize) callconv(.c) void = null,
 
     /// Called when a grid receives a grid_scroll event.
     /// Frontend should clear pixel-based smooth scroll offset for this grid.

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -247,10 +247,11 @@ pub const Callbacks = struct {
     on_tabline_hide: ?*const fn (ctx: ?*anyopaque) callconv(.c) void = null,
 
     /// AI-agent work status for a tabpage (from the zonvie_agent_status RPC
-    /// notification). state: 0=none, 1=idle (agent present), 2=working/claude,
-    /// 3=working/braille (codex & generic). The frontend renders/animates the
-    /// per-tab indicator from this; fired immediately on change (not coupled to
-    /// redraw, so a background-tab agent still updates).
+    /// notification). state: 0=none, 1=idle (agent present, done),
+    /// 2=working/claude, 3=working/braille (codex & generic),
+    /// 4=waiting for user input (a decision prompt is on screen). The frontend
+    /// renders/animates the per-tab indicator from this; fired immediately on
+    /// change (not coupled to redraw, so a background-tab agent still updates).
     on_agent_status: ?*const fn (ctx: ?*anyopaque, tab_handle: i64, state: u8, title: [*]const u8, title_len: usize) callconv(.c) void = null,
 
     /// Called when a grid receives a grid_scroll event.

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -839,6 +839,9 @@ pub fn setupClipboard(self: *Core) void {
 /// spinner is treated as codex/generic). The frontend renders/animates from the
 /// state. augroup clear=true keeps re-injection idempotent. Fire-and-forget.
 pub fn setupAgentStatus(self: *Core) void {
+    // Skip the reporter entirely when both the indicator and the completion
+    // notification are disabled -- nothing would consume the status updates.
+    if (!self.msg_config.tabline.agent_indicator and !self.msg_config.tabline.agent_notification) return;
     const lua_code =
         \\local present, kind, last = {}, {}, {}
         \\local function classify(buf, title)

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -844,13 +844,35 @@ pub fn setupAgentStatus(self: *Core) void {
     if (!self.msg_config.tabline.agent_indicator and !self.msg_config.tabline.agent_notification) return;
     const lua_code =
         \\local present, kind, last = {}, {}, {}
+        \\-- Scrape the terminal tail for a pending decision prompt (permission /
+        \\-- yes-no / numbered choice). This is how an agent "waiting for the user"
+        \\-- is told apart from "done"; the title alone can't (both look idle).
+        \\-- Conservative, English-string patterns -- fragile by nature.
+        \\local function waiting_prompt(buf)
+        \\  local ok, lines = pcall(vim.api.nvim_buf_get_lines, buf, -20, -1, false)
+        \\  if not ok then return false end
+        \\  local t = table.concat(lines, '\n')
+        \\  -- Selection-menu footer (AskUserQuestion / ExitPlanMode / permission):
+        \\  -- present only while an interactive prompt is on screen, language-agnostic.
+        \\  return t:find('Enter to select') ~= nil or t:find('to navigate') ~= nil
+        \\    or t:find('Esc to cancel') ~= nil or t:find('Do you want') ~= nil
+        \\    or t:find('to proceed') ~= nil or t:find('tell Claude') ~= nil
+        \\    or t:find('%[y/n%]') ~= nil or t:find('Allow command') ~= nil
+        \\end
+        \\local function spinning(title)
+        \\  local cp = title ~= '' and vim.fn.char2nr(title) or 0
+        \\  return cp >= 0x2800 and cp <= 0x28FF
+        \\end
+        \\-- classify returns 2/3 = working, 0 = gone, 1 = present-but-stopped
+        \\-- (done OR waiting -- decided later by a deferred scrape, because the
+        \\-- prompt box may not be in the buffer yet at the instant the spinner stops).
         \\local function classify(buf, title)
         \\  local cp = title ~= '' and vim.fn.char2nr(title) or 0
-        \\  local spinner = cp >= 0x2800 and cp <= 0x28FF
+        \\  local spin = cp >= 0x2800 and cp <= 0x28FF
         \\  local claudeish = cp == 0x2733 or title:find('Claude') ~= nil
         \\  if claudeish then present[buf] = true; kind[buf] = 'claude' end
-        \\  if spinner then present[buf] = true; if not kind[buf] then kind[buf] = 'braille' end end
-        \\  if spinner then return (kind[buf] == 'claude') and 2 or 3 end
+        \\  if spin then present[buf] = true; if not kind[buf] then kind[buf] = 'braille' end end
+        \\  if spin then return (kind[buf] == 'claude') and 2 or 3 end
         \\  if claudeish then return 1 end
         \\  -- Claude always shows the U+2733 marker when idle; a claude tab whose
         \\  -- title lost every agent marker means Claude exited (the shell took the
@@ -873,6 +895,22 @@ pub fn setupAgentStatus(self: *Core) void {
         \\  last[tab] = state
         \\  vim.rpcnotify(0, 'zonvie_agent_status', { tab = tab, state = state, title = title or '' })
         \\end
+        \\-- The done-vs-waiting decision is deferred ~0.8s after the spinner stops,
+        \\-- so the prompt box has time to render into the buffer before we scrape.
+        \\-- pend[buf] is a token that any newer event bumps to cancel a stale decision.
+        \\local pend = {}
+        \\local function decide_stopped(buf, title)
+        \\  pend[buf] = (pend[buf] or 0) + 1
+        \\  local tok = pend[buf]
+        \\  vim.defer_fn(function()
+        \\    if pend[buf] ~= tok then return end
+        \\    if not (vim.api.nvim_buf_is_valid(buf) and present[buf]) then return end
+        \\    local ok, t = pcall(function() return vim.b[buf].term_title end)
+        \\    if ok and spinning(t or '') then return end
+        \\    local s = waiting_prompt(buf) and 4 or 1
+        \\    for _, tab in ipairs(tabs_for_buf(buf)) do report(tab, s, title) end
+        \\  end, 800)
+        \\end
         \\local grp = vim.api.nvim_create_augroup('zonvie_agent_status', { clear = true })
         \\vim.api.nvim_create_autocmd('TermRequest', {
         \\  group = grp,
@@ -883,12 +921,18 @@ pub fn setupAgentStatus(self: *Core) void {
         \\    local s = classify(ev.buf, body)
         \\    local cp0 = body ~= '' and vim.fn.char2nr(body) or 0
         \\    local title = (cp0 == 0x2733 or (cp0 >= 0x2800 and cp0 <= 0x28FF)) and (body:gsub('^[^ ]+%s*', '')) or body
-        \\    for _, tab in ipairs(tabs_for_buf(ev.buf)) do report(tab, s, title) end
+        \\    if s == 1 then
+        \\      decide_stopped(ev.buf, title)
+        \\    else
+        \\      pend[ev.buf] = (pend[ev.buf] or 0) + 1
+        \\      for _, tab in ipairs(tabs_for_buf(ev.buf)) do report(tab, s, title) end
+        \\    end
         \\  end,
         \\})
         \\vim.api.nvim_create_autocmd('TermClose', {
         \\  group = grp,
         \\  callback = function(ev)
+        \\    pend[ev.buf] = (pend[ev.buf] or 0) + 1
         \\    present[ev.buf] = nil; kind[ev.buf] = nil
         \\    for _, tab in ipairs(tabs_for_buf(ev.buf)) do report(tab, 0) end
         \\  end,
@@ -907,10 +951,12 @@ pub fn setupAgentStatus(self: *Core) void {
         \\      -- Gone if the title is empty (zsh after exit), or a claude tab no
         \\      -- longer shows any agent marker (cmd.exe took the title over).
         \\      if t == '' or (kind[buf] == 'claude' and not agentish) then
+        \\        pend[buf] = (pend[buf] or 0) + 1
         \\        present[buf] = nil; kind[buf] = nil
         \\        for _, tab in ipairs(tabs_for_buf(buf)) do report(tab, 0) end
         \\      end
         \\    else
+        \\      pend[buf] = (pend[buf] or 0) + 1
         \\      present[buf] = nil; kind[buf] = nil
         \\    end
         \\  end
@@ -1299,8 +1345,9 @@ pub fn handleRpcNotification(self: *Core, arena: std.mem.Allocator, top: []mp.Va
         }
     } else if (std.mem.eql(u8, method, "zonvie_agent_status")) {
         // Custom RPC notification: AI-agent work state for one tabpage.
-        // params[0] = { tab: Integer (tabpage handle), state: Integer 0..3 }
-        //   0=none, 1=idle (agent present), 2=working/claude, 3=working/braille.
+        // params[0] = { tab, state: Integer 0..4, title: String }
+        //   0=none, 1=idle (agent present, done), 2=working/claude,
+        //   3=working/braille, 4=waiting for user input (decision prompt on screen).
         // Emitted (debounced) by the auto-injected reporter. Forwarded straight
         // to the frontend, which owns the per-tab indicator + spinner animation.
         // Not coupled to grid/redraw, so a background-tab agent still updates.
@@ -1317,7 +1364,7 @@ pub fn handleRpcNotification(self: *Core, arena: std.mem.Allocator, top: []mp.Va
                         have_tab = true;
                     }
                 } else if (std.mem.eql(u8, pair.key.str, "state")) {
-                    if (pair.val == .int and pair.val.int >= 0 and pair.val.int <= 3) {
+                    if (pair.val == .int and pair.val.int >= 0 and pair.val.int <= 4) {
                         state = @intCast(pair.val.int);
                     }
                 } else if (std.mem.eql(u8, pair.key.str, "title")) {

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -844,9 +844,15 @@ pub fn setupAgentStatus(self: *Core) void {
         \\local function classify(buf, title)
         \\  local cp = title ~= '' and vim.fn.char2nr(title) or 0
         \\  local spinner = cp >= 0x2800 and cp <= 0x28FF
-        \\  if cp == 0x2733 or title:find('Claude') then present[buf] = true; kind[buf] = 'claude' end
+        \\  local claudeish = cp == 0x2733 or title:find('Claude') ~= nil
+        \\  if claudeish then present[buf] = true; kind[buf] = 'claude' end
         \\  if spinner then present[buf] = true; if not kind[buf] then kind[buf] = 'braille' end end
         \\  if spinner then return (kind[buf] == 'claude') and 2 or 3 end
+        \\  if claudeish then return 1 end
+        \\  -- Claude always shows the U+2733 marker when idle; a claude tab whose
+        \\  -- title lost every agent marker means Claude exited (the shell took the
+        \\  -- title over, e.g. cmd.exe) -> clear so the robot indicator goes away.
+        \\  if kind[buf] == 'claude' then present[buf] = nil; kind[buf] = nil; return 0 end
         \\  if present[buf] then return 1 end
         \\  return 0
         \\end
@@ -892,7 +898,12 @@ pub fn setupAgentStatus(self: *Core) void {
         \\  for buf in pairs(present) do
         \\    if vim.api.nvim_buf_is_valid(buf) and vim.bo[buf].buftype == 'terminal' then
         \\      local ok, t = pcall(function() return vim.b[buf].term_title end)
-        \\      if ok and (t == nil or t == '') then
+        \\      t = (ok and t) or ''
+        \\      local cp = t ~= '' and vim.fn.char2nr(t) or 0
+        \\      local agentish = cp == 0x2733 or (cp >= 0x2800 and cp <= 0x28FF) or t:find('Claude') ~= nil
+        \\      -- Gone if the title is empty (zsh after exit), or a claude tab no
+        \\      -- longer shows any agent marker (cmd.exe took the title over).
+        \\      if t == '' or (kind[buf] == 'claude' and not agentish) then
         \\        present[buf] = nil; kind[buf] = nil
         \\        for _, tab in ipairs(tabs_for_buf(buf)) do report(tab, 0) end
         \\      end

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -859,10 +859,10 @@ pub fn setupAgentStatus(self: *Core) void {
         \\  end
         \\  return out
         \\end
-        \\local function report(tab, state)
+        \\local function report(tab, state, title)
         \\  if last[tab] == state then return end
         \\  last[tab] = state
-        \\  vim.rpcnotify(0, 'zonvie_agent_status', { tab = tab, state = state })
+        \\  vim.rpcnotify(0, 'zonvie_agent_status', { tab = tab, state = state, title = title or '' })
         \\end
         \\local grp = vim.api.nvim_create_augroup('zonvie_agent_status', { clear = true })
         \\vim.api.nvim_create_autocmd('TermRequest', {
@@ -872,7 +872,9 @@ pub fn setupAgentStatus(self: *Core) void {
         \\    local body = seq:match('^\27%]0;(.*)$') or seq:match('^\27%]1;(.*)$') or seq:match('^\27%]2;(.*)$')
         \\    if not body then return end
         \\    local s = classify(ev.buf, body)
-        \\    for _, tab in ipairs(tabs_for_buf(ev.buf)) do report(tab, s) end
+        \\    local cp0 = body ~= '' and vim.fn.char2nr(body) or 0
+        \\    local title = (cp0 == 0x2733 or (cp0 >= 0x2800 and cp0 <= 0x28FF)) and (body:gsub('^[^ ]+%s*', '')) or body
+        \\    for _, tab in ipairs(tabs_for_buf(ev.buf)) do report(tab, s, title) end
         \\  end,
         \\})
         \\vim.api.nvim_create_autocmd('TermClose', {
@@ -1292,6 +1294,7 @@ pub fn handleRpcNotification(self: *Core, arena: std.mem.Allocator, top: []mp.Va
             var tab_handle: i64 = 0;
             var have_tab = false;
             var state: u8 = 0;
+            var title: []const u8 = "";
             for (params[0].map) |pair| {
                 if (pair.key != .str) continue;
                 if (std.mem.eql(u8, pair.key.str, "tab")) {
@@ -1303,10 +1306,12 @@ pub fn handleRpcNotification(self: *Core, arena: std.mem.Allocator, top: []mp.Va
                     if (pair.val == .int and pair.val.int >= 0 and pair.val.int <= 3) {
                         state = @intCast(pair.val.int);
                     }
+                } else if (std.mem.eql(u8, pair.key.str, "title")) {
+                    if (pair.val == .str) title = pair.val.str;
                 }
             }
             if (have_tab) {
-                if (self.cb.on_agent_status) |cb| cb(self.ctx, tab_handle, state);
+                if (self.cb.on_agent_status) |cb| cb(self.ctx, tab_handle, state, title.ptr, title.len);
             }
         }
     }

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -830,6 +830,84 @@ pub fn setupClipboard(self: *Core) void {
     self.log.write("clipboard setup done (via nvim_list_chans lookup)\n", .{});
 }
 
+/// Inject the AI-agent tab-status reporter into the connected Neovim so the
+/// feature needs no user-side config. Classifies each terminal's OSC title into
+/// a per-tabpage state and reports it via the zonvie_agent_status notification:
+///   0=none  1=idle (agent present)  2=working/claude  3=working/braille(codex).
+/// Agent presence + kind are latched per buffer (claude is recognized by its
+/// '✳' U+2733 idle marker or "Claude" in the title; anything else with a Braille
+/// spinner is treated as codex/generic). The frontend renders/animates from the
+/// state. augroup clear=true keeps re-injection idempotent. Fire-and-forget.
+pub fn setupAgentStatus(self: *Core) void {
+    const lua_code =
+        \\local present, kind, last = {}, {}, {}
+        \\local function classify(buf, title)
+        \\  local cp = title ~= '' and vim.fn.char2nr(title) or 0
+        \\  local spinner = cp >= 0x2800 and cp <= 0x28FF
+        \\  if cp == 0x2733 or title:find('Claude') then present[buf] = true; kind[buf] = 'claude' end
+        \\  if spinner then present[buf] = true; if not kind[buf] then kind[buf] = 'braille' end end
+        \\  if spinner then return (kind[buf] == 'claude') and 2 or 3 end
+        \\  if present[buf] then return 1 end
+        \\  return 0
+        \\end
+        \\local function tabs_for_buf(buf)
+        \\  local out = {}
+        \\  for _, t in ipairs(vim.api.nvim_list_tabpages()) do
+        \\    for _, w in ipairs(vim.api.nvim_tabpage_list_wins(t)) do
+        \\      if vim.api.nvim_win_get_buf(w) == buf then out[#out+1] = t; break end
+        \\    end
+        \\  end
+        \\  return out
+        \\end
+        \\local function report(tab, state)
+        \\  if last[tab] == state then return end
+        \\  last[tab] = state
+        \\  vim.rpcnotify(0, 'zonvie_agent_status', { tab = tab, state = state })
+        \\end
+        \\local grp = vim.api.nvim_create_augroup('zonvie_agent_status', { clear = true })
+        \\vim.api.nvim_create_autocmd('TermRequest', {
+        \\  group = grp,
+        \\  callback = function(ev)
+        \\    local seq = ev.data and ev.data.sequence or ''
+        \\    local body = seq:match('^\27%]0;(.*)$') or seq:match('^\27%]1;(.*)$') or seq:match('^\27%]2;(.*)$')
+        \\    if not body then return end
+        \\    local s = classify(ev.buf, body)
+        \\    for _, tab in ipairs(tabs_for_buf(ev.buf)) do report(tab, s) end
+        \\  end,
+        \\})
+        \\vim.api.nvim_create_autocmd('TermClose', {
+        \\  group = grp,
+        \\  callback = function(ev)
+        \\    present[ev.buf] = nil; kind[ev.buf] = nil
+        \\    for _, tab in ipairs(tabs_for_buf(ev.buf)) do report(tab, 0) end
+        \\  end,
+        \\})
+        \\-- Agent exit (claude/codex quit while the shell stays open) clears the
+        \\-- terminal title to "" but fires NO TermRequest, so poll present
+        \\-- buffers and drop the indicator when the title goes empty.
+        \\if _G.__zonvie_agent_timer then pcall(vim.fn.timer_stop, _G.__zonvie_agent_timer) end
+        \\_G.__zonvie_agent_timer = vim.fn.timer_start(500, function()
+        \\  for buf in pairs(present) do
+        \\    if vim.api.nvim_buf_is_valid(buf) and vim.bo[buf].buftype == 'terminal' then
+        \\      local ok, t = pcall(function() return vim.b[buf].term_title end)
+        \\      if ok and (t == nil or t == '') then
+        \\        present[buf] = nil; kind[buf] = nil
+        \\        for _, tab in ipairs(tabs_for_buf(buf)) do report(tab, 0) end
+        \\      end
+        \\    else
+        \\      present[buf] = nil; kind[buf] = nil
+        \\    end
+        \\  end
+        \\end, { ['repeat'] = -1 })
+    ;
+
+    self.requestExecLua(lua_code) catch |e| {
+        self.log.write("setupAgentStatus: requestExecLua failed: {any}\n", .{e});
+        return;
+    };
+    self.log.write("agent status reporter installed\n", .{});
+}
+
 pub fn handleRpcNotification(self: *Core, arena: std.mem.Allocator, top: []mp.Value) void {
     if (top.len < 3) return;
     if (top[1] != .str or top[2] != .arr) return;
@@ -1202,6 +1280,34 @@ pub fn handleRpcNotification(self: *Core, arena: std.mem.Allocator, top: []mp.Va
                 else if (std.mem.eql(u8, val_str, "only_right")) 3
                 else return;  // unknown value: keep existing setting
             self.option_as_meta.store(val, .release);
+        }
+    } else if (std.mem.eql(u8, method, "zonvie_agent_status")) {
+        // Custom RPC notification: AI-agent work state for one tabpage.
+        // params[0] = { tab: Integer (tabpage handle), state: Integer 0..3 }
+        //   0=none, 1=idle (agent present), 2=working/claude, 3=working/braille.
+        // Emitted (debounced) by the auto-injected reporter. Forwarded straight
+        // to the frontend, which owns the per-tab indicator + spinner animation.
+        // Not coupled to grid/redraw, so a background-tab agent still updates.
+        if (params.len > 0 and params[0] == .map) {
+            var tab_handle: i64 = 0;
+            var have_tab = false;
+            var state: u8 = 0;
+            for (params[0].map) |pair| {
+                if (pair.key != .str) continue;
+                if (std.mem.eql(u8, pair.key.str, "tab")) {
+                    if (pair.val == .int) {
+                        tab_handle = pair.val.int;
+                        have_tab = true;
+                    }
+                } else if (std.mem.eql(u8, pair.key.str, "state")) {
+                    if (pair.val == .int and pair.val.int >= 0 and pair.val.int <= 3) {
+                        state = @intCast(pair.val.int);
+                    }
+                }
+            }
+            if (have_tab) {
+                if (self.cb.on_agent_status) |cb| cb(self.ctx, tab_handle, state);
+            }
         }
     }
 }
@@ -1701,6 +1807,9 @@ pub fn runLoop(self: *Core) void {
         // Discover our channel_id via vim.api.nvim_list_chans() and install
         // the clipboard provider hooks.
         setupClipboard(self);
+
+        // Install the AI-agent tab-status reporter (zero user-side config).
+        setupAgentStatus(self);
 
         if (self.pending_resize_valid) {
             const pr2 = self.pending_resize_rows;

--- a/src/core/rpc_session.zig
+++ b/src/core/rpc_session.zig
@@ -1355,6 +1355,7 @@ pub fn handleRpcNotification(self: *Core, arena: std.mem.Allocator, top: []mp.Va
             var tab_handle: i64 = 0;
             var have_tab = false;
             var state: u8 = 0;
+            var have_state = false;
             var title: []const u8 = "";
             for (params[0].map) |pair| {
                 if (pair.key != .str) continue;
@@ -1366,12 +1367,16 @@ pub fn handleRpcNotification(self: *Core, arena: std.mem.Allocator, top: []mp.Va
                 } else if (std.mem.eql(u8, pair.key.str, "state")) {
                     if (pair.val == .int and pair.val.int >= 0 and pair.val.int <= 4) {
                         state = @intCast(pair.val.int);
+                        have_state = true;
                     }
                 } else if (std.mem.eql(u8, pair.key.str, "title")) {
                     if (pair.val == .str) title = pair.val.str;
                 }
             }
-            if (have_tab) {
+            // Require an explicit, valid state. A notification with only `tab`
+            // (state missing or out of range) must NOT fire with state=0, which
+            // would erase a working tab's indicator on malformed input.
+            if (have_tab and have_state) {
                 if (self.cb.on_agent_status) |cb| cb(self.ctx, tab_handle, state, title.ptr, title.len);
             }
         }

--- a/test/gui/fixtures/config_tabline/zonvie/config.toml
+++ b/test/gui/fixtures/config_tabline/zonvie/config.toml
@@ -1,0 +1,5 @@
+# ext_tabline enabled (titlebar/Chrome-style tabs) for the agent-status
+# visual scenario.
+[tabline]
+external = true
+style = "titlebar"

--- a/test/gui/runner.zig
+++ b/test/gui/runner.zig
@@ -103,6 +103,16 @@ test "gui:visual_baseline" {
     }
 }
 
+test "gui:visual_agent_status" {
+    if (comptime driver.capture.supported) {
+        try requirePrereqs();
+        try @import("scenarios/visual/agent_status.zig").run(testing.allocator);
+    } else {
+        std.debug.print("[gui] skipped: screenshot capture not implemented on this host\n", .{});
+        return error.SkipZigTest;
+    }
+}
+
 test "gui:visual_split" {
     if (comptime driver.capture.supported) {
         try requirePrereqs();

--- a/test/gui/scenarios/visual/agent_status.zig
+++ b/test/gui/scenarios/visual/agent_status.zig
@@ -1,0 +1,38 @@
+// visual/agent_status — verify the AI-agent "working" glyph paints on the tab.
+//
+// The core prepends "● " to a working agent's tab name; the frontend must
+// preserve it across the path-basename beautification and actually draw it.
+// We exercise the core->render path directly by broadcasting the
+// zonvie_agent_status notification (no real agent needed), then capture the
+// tab bar so the result can be inspected.
+
+const std = @import("std");
+const driver = @import("../../driver.zig");
+const capture = driver.capture;
+const Gui = driver.Gui;
+
+pub fn run(alloc: std.mem.Allocator) !void {
+    var g = try Gui.init(alloc, .{
+        .config_dir = "test/gui/fixtures/config_tabline",
+        .app_args = &.{ "--log", "tmp/gui_agent.log" },
+    });
+    defer g.deinit();
+
+    driver.platform.pinWindow(g.app_pid, 80, 80);
+    try g.exec("execute('set guicursor+=a:blinkon0')");
+    try g.exec("execute('set guifont=Menlo:h13')");
+    try g.exec("execute('set showtabline=2')");
+    // A named buffer so the single tab has a visible label.
+    try g.exec("execute('edit agentwork.txt')");
+
+    // Mark tabpage handle 1 (the first/only tabpage) as a working agent,
+    // bypassing the OSC reporter to test core decoration + rendering directly.
+    try g.exec("rpcnotify(0, 'zonvie_agent_status', {'tab': 1, 'status': 'working'})");
+    // Force a redraw so the dirty tabline re-emits with the decorated name.
+    try g.exec("execute('redraw!')");
+
+    var img = try g.captureStable(.{ .w_pt = 900, .h_pt = 140 }, 8000);
+    defer img.deinit(alloc);
+    try capture.writeImage(alloc, "tmp/agent_status_actual.png", img);
+    std.debug.print("[gui] wrote tmp/agent_status_actual.png ({d}x{d})\n", .{ img.w, img.h });
+}

--- a/test/gui/scenarios/visual/agent_status.zig
+++ b/test/gui/scenarios/visual/agent_status.zig
@@ -1,7 +1,7 @@
 // visual/agent_status — verify the AI-agent "working" glyph paints on the tab.
 //
-// The core prepends "● " to a working agent's tab name; the frontend must
-// preserve it across the path-basename beautification and actually draw it.
+// The core forwards the per-tab `state` straight to the frontend, which owns
+// the indicator glyph + spinner animation (the core does not decorate names).
 // We exercise the core->render path directly by broadcasting the
 // zonvie_agent_status notification (no real agent needed), then capture the
 // tab bar so the result can be inspected.
@@ -26,9 +26,10 @@ pub fn run(alloc: std.mem.Allocator) !void {
     try g.exec("execute('edit agentwork.txt')");
 
     // Mark tabpage handle 1 (the first/only tabpage) as a working agent,
-    // bypassing the OSC reporter to test core decoration + rendering directly.
-    try g.exec("rpcnotify(0, 'zonvie_agent_status', {'tab': 1, 'status': 'working'})");
-    // Force a redraw so the dirty tabline re-emits with the decorated name.
+    // bypassing the OSC reporter to test rendering directly. state=3 is the
+    // generic/braille "working" spinner (the parser reads an integer `state`).
+    try g.exec("rpcnotify(0, 'zonvie_agent_status', {'tab': 1, 'state': 3})");
+    // Force a redraw so the dirty tabline re-emits with the indicator.
     try g.exec("execute('redraw!')");
 
     var img = try g.captureStable(.{ .w_pt = 900, .h_pt = 140 }, 8000);

--- a/windows/app.zig
+++ b/windows/app.zig
@@ -170,6 +170,10 @@ pub const TIMER_TRAY_INIT: c.UINT_PTR = 9;
 pub const TIMER_CUSTOM_SHADER_ANIM: c.UINT_PTR = 11;
 /// ~60Hz cadence for TIMER_CUSTOM_SHADER_ANIM.
 pub const CUSTOM_SHADER_ANIM_INTERVAL_MS: c.UINT = 16;
+/// AI-agent tab spinner animation timer (only runs while a tab is working).
+pub const TIMER_AGENT_SPINNER: c.UINT_PTR = 12;
+/// Frame cadence for the agent spinner (matches Claude Code's 120ms).
+pub const AGENT_SPINNER_INTERVAL_MS: c.UINT = 120;
 /// Tray icon init delay in milliseconds
 pub const TRAY_INIT_DELAY_MS: c.UINT = 50;
 /// Quit timeout in milliseconds (5 seconds)
@@ -995,6 +999,14 @@ pub const TablineState = struct {
     // Window button pressed state (for proper click handling on min/max/close)
     pressed_window_btn: ?u8 = null, // 0=min, 1=max, 2=close
 
+    // AI-agent indicator state, keyed by tab handle (set via on_agent_status).
+    // state: 1=idle (agent present)→●, 2=working/claude, 3=working/braille.
+    agent_handles: [32]i64 = [_]i64{0} ** 32,
+    agent_states: [32]u8 = [_]u8{0} ** 32,
+    agent_count: usize = 0,
+    spinner_frame: u32 = 0,
+    spinner_timer_active: bool = false,
+
     // Tab bar constants
     pub const TAB_BAR_HEIGHT: c_int = 32;
     pub const TAB_MIN_WIDTH: c_int = 100;
@@ -1022,6 +1034,44 @@ pub const TablineState = struct {
         self.tab_count = 0;
         self.current_tab = 0;
         self.visible = false;
+    }
+
+    /// Upsert/remove (state==0) the AI-agent state for a tab handle.
+    pub fn setAgentState(self: *TablineState, handle: i64, state: u8) void {
+        var i: usize = 0;
+        while (i < self.agent_count) : (i += 1) {
+            if (self.agent_handles[i] == handle) {
+                if (state == 0) {
+                    self.agent_count -= 1;
+                    self.agent_handles[i] = self.agent_handles[self.agent_count];
+                    self.agent_states[i] = self.agent_states[self.agent_count];
+                } else {
+                    self.agent_states[i] = state;
+                }
+                return;
+            }
+        }
+        if (state != 0 and self.agent_count < 32) {
+            self.agent_handles[self.agent_count] = handle;
+            self.agent_states[self.agent_count] = state;
+            self.agent_count += 1;
+        }
+    }
+
+    pub fn agentState(self: *const TablineState, handle: i64) u8 {
+        var i: usize = 0;
+        while (i < self.agent_count) : (i += 1) {
+            if (self.agent_handles[i] == handle) return self.agent_states[i];
+        }
+        return 0;
+    }
+
+    pub fn anyAgentWorking(self: *const TablineState) bool {
+        var i: usize = 0;
+        while (i < self.agent_count) : (i += 1) {
+            if (self.agent_states[i] == 2 or self.agent_states[i] == 3) return true;
+        }
+        return false;
     }
 
     pub fn cancelDrag(self: *TablineState) void {

--- a/windows/app.zig
+++ b/windows/app.zig
@@ -89,6 +89,31 @@ pub const MsgHistoryEntry = core.MsgHistoryEntry;
 pub const zonvie_msg_event = core.zonvie_msg_event;
 
 // =========================================================================
+// Small shared text helpers
+// =========================================================================
+
+/// Length of the longest prefix of `s` that fits in `max_bytes` without
+/// splitting a UTF-8 codepoint. Used to truncate user text before copying into
+/// a fixed buffer so later UTF-16 conversion can't see a partial codepoint.
+pub fn utf8TruncLen(s: []const u8, max_bytes: usize) usize {
+    var n = @min(s.len, max_bytes);
+    // Back up off any UTF-8 continuation byte (0b10xxxxxx) so we end on a
+    // codepoint boundary.
+    while (n > 0 and (s[n - 1] & 0xC0) == 0x80) n -= 1;
+    return n;
+}
+
+/// Basename of a path-like name: the part after the last '/' or '\\'.
+/// Returns the whole string when there is no separator.
+pub fn baseName(name: []const u8) []const u8 {
+    var last: usize = 0;
+    for (name, 0..) |ch, j| {
+        if (ch == '/' or ch == '\\') last = j + 1;
+    }
+    return name[last..];
+}
+
+// =========================================================================
 // Custom window messages (WM_APP + N)
 // =========================================================================
 
@@ -849,11 +874,19 @@ pub const TrayIcon = struct {
         self.nid.dwInfoFlags = c.NIIF_INFO;
 
         // Title -> szInfoTitle (proper UTF-8 -> UTF-16; byte-copy garbles non-ASCII).
-        const tn = std.unicode.utf8ToUtf16Le(self.nid.szInfoTitle[0..63], title) catch 0;
+        // utf8ToUtf16Le does NOT bounds-check its destination, so the source must
+        // be truncated to fit first. Each UTF-8 codepoint yields <= as many UTF-16
+        // units as bytes, so bounding the source to the dest u16 capacity (minus
+        // the null terminator slot) guarantees the conversion stays in bounds.
+        const title_cap = self.nid.szInfoTitle.len - 1;
+        const tt = title[0..utf8TruncLen(title, title_cap)];
+        const tn = std.unicode.utf8ToUtf16Le(self.nid.szInfoTitle[0..title_cap], tt) catch 0;
         self.nid.szInfoTitle[tn] = 0;
 
-        // Message -> szInfo (proper UTF-8 -> UTF-16).
-        const mn = std.unicode.utf8ToUtf16Le(self.nid.szInfo[0..255], msg_text) catch 0;
+        // Message -> szInfo (proper UTF-8 -> UTF-16, same bounding rule).
+        const msg_cap = self.nid.szInfo.len - 1;
+        const mt = msg_text[0..utf8TruncLen(msg_text, msg_cap)];
+        const mn = std.unicode.utf8ToUtf16Le(self.nid.szInfo[0..msg_cap], mt) catch 0;
         self.nid.szInfo[mn] = 0;
 
         _ = c.Shell_NotifyIconW(c.NIM_MODIFY, &self.nid);
@@ -1089,7 +1122,10 @@ pub const TablineState = struct {
         if (self.agent_completed_count < self.agent_completed.len) {
             const idx = self.agent_completed_count;
             self.agent_completed[idx] = handle;
-            const n = @min(title.len, self.agent_completed_titles[idx].len);
+            // Truncate on a UTF-8 boundary so the stored title never holds a
+            // partial codepoint (which would later fail UTF-16 conversion and
+            // produce an empty balloon body).
+            const n = utf8TruncLen(title, self.agent_completed_titles[idx].len);
             @memcpy(self.agent_completed_titles[idx][0..n], title[0..n]);
             self.agent_completed_title_lens[idx] = n;
             self.agent_completed_waiting[idx] = waiting;
@@ -1102,12 +1138,7 @@ pub const TablineState = struct {
         var i: usize = 0;
         while (i < self.tab_count) : (i += 1) {
             if (self.tabs[i].handle == handle) {
-                const full = self.tabs[i].name[0..self.tabs[i].name_len];
-                var last: usize = 0;
-                for (full, 0..) |ch, j| {
-                    if (ch == '/' or ch == '\\') last = j + 1;
-                }
-                return full[last..];
+                return baseName(self.tabs[i].name[0..self.tabs[i].name_len]);
             }
         }
         return "";

--- a/windows/app.zig
+++ b/windows/app.zig
@@ -1007,6 +1007,12 @@ pub const TablineState = struct {
     spinner_frame: u32 = 0,
     spinner_timer_active: bool = false,
 
+    // Cached color-emoji bitmap for the idle indicator (🤖), rasterized via
+    // D2D and AlphaBlend'd onto the tab (GDI DrawTextW can't render color
+    // emoji). Re-rasterized only on size change; freed in App deinit.
+    agent_emoji_hbm: ?c.HBITMAP = null,
+    agent_emoji_px: i32 = 0,
+
     // Tab bar constants
     pub const TAB_BAR_HEIGHT: c_int = 32;
     pub const TAB_MIN_WIDTH: c_int = 100;
@@ -3080,6 +3086,12 @@ pub const App = struct {
     }
 
     pub fn deinit(self: *App) void {
+        // Cached AI-agent color-emoji bitmap (tabline idle indicator).
+        if (self.tabline_state.agent_emoji_hbm) |hbm| {
+            _ = c.DeleteObject(hbm);
+            self.tabline_state.agent_emoji_hbm = null;
+        }
+
         // Main surface: release GPU VBs from row_verts, then CPU state
         for (self.surface.row_verts.items) |*rv| {
             if (rv.vb) |p| {

--- a/windows/app.zig
+++ b/windows/app.zig
@@ -848,23 +848,13 @@ pub const TrayIcon = struct {
         self.nid.uFlags = c.NIF_INFO;
         self.nid.dwInfoFlags = c.NIIF_INFO;
 
-        // Copy title to szInfoTitle (max 63 chars + null)
-        var title_buf: [64]u16 = undefined;
-        const title_len = @min(title.len, 63);
-        for (0..title_len) |i| {
-            title_buf[i] = title[i];
-        }
-        title_buf[title_len] = 0;
-        @memcpy(self.nid.szInfoTitle[0 .. title_len + 1], title_buf[0 .. title_len + 1]);
+        // Title -> szInfoTitle (proper UTF-8 -> UTF-16; byte-copy garbles non-ASCII).
+        const tn = std.unicode.utf8ToUtf16Le(self.nid.szInfoTitle[0..63], title) catch 0;
+        self.nid.szInfoTitle[tn] = 0;
 
-        // Copy msg to szInfo (max 255 chars + null)
-        var msg_buf: [256]u16 = undefined;
-        const msg_len = @min(msg_text.len, 255);
-        for (0..msg_len) |i| {
-            msg_buf[i] = msg_text[i];
-        }
-        msg_buf[msg_len] = 0;
-        @memcpy(self.nid.szInfo[0 .. msg_len + 1], msg_buf[0 .. msg_len + 1]);
+        // Message -> szInfo (proper UTF-8 -> UTF-16).
+        const mn = std.unicode.utf8ToUtf16Le(self.nid.szInfo[0..255], msg_text) catch 0;
+        self.nid.szInfo[mn] = 0;
 
         _ = c.Shell_NotifyIconW(c.NIM_MODIFY, &self.nid);
         if (applog.isEnabled()) applog.appLog("[tray] showBalloon: title='{s}' msg='{s}'\n", .{ title, msg_text });

--- a/windows/app.zig
+++ b/windows/app.zig
@@ -1003,6 +1003,8 @@ pub const TablineState = struct {
     // Agent title/summary captured at each completion (parallel to agent_completed).
     agent_completed_titles: [32][128]u8 = undefined,
     agent_completed_title_lens: [32]usize = [_]usize{0} ** 32,
+    // true = paused waiting for user input; false = finished (parallel array).
+    agent_completed_waiting: [32]bool = [_]bool{false} ** 32,
     agent_completed_count: usize = 0,
 
     // Cached color-emoji bitmap for the idle indicator (🤖), rasterized via
@@ -1078,8 +1080,8 @@ pub const TablineState = struct {
         return false;
     }
 
-    /// Queue a completed tab handle + its title (de-duplicated, capped).
-    pub fn pushCompleted(self: *TablineState, handle: i64, title: []const u8) void {
+    /// Queue a finished/waiting tab handle + its title (de-duplicated, capped).
+    pub fn pushCompleted(self: *TablineState, handle: i64, title: []const u8, waiting: bool) void {
         var i: usize = 0;
         while (i < self.agent_completed_count) : (i += 1) {
             if (self.agent_completed[i] == handle) return;
@@ -1090,6 +1092,7 @@ pub const TablineState = struct {
             const n = @min(title.len, self.agent_completed_titles[idx].len);
             @memcpy(self.agent_completed_titles[idx][0..n], title[0..n]);
             self.agent_completed_title_lens[idx] = n;
+            self.agent_completed_waiting[idx] = waiting;
             self.agent_completed_count += 1;
         }
     }

--- a/windows/app.zig
+++ b/windows/app.zig
@@ -1006,6 +1006,14 @@ pub const TablineState = struct {
     agent_count: usize = 0,
     spinner_frame: u32 = 0,
     spinner_timer_active: bool = false,
+    // Tab handles that just finished (working 2/3 -> idle 1). Drained on the UI
+    // thread for per-tab completion notifications; kept (not dropped) until the
+    // tray is ready so a startup-race completion isn't silently lost.
+    agent_completed: [32]i64 = [_]i64{0} ** 32,
+    // Agent title/summary captured at each completion (parallel to agent_completed).
+    agent_completed_titles: [32][128]u8 = undefined,
+    agent_completed_title_lens: [32]usize = [_]usize{0} ** 32,
+    agent_completed_count: usize = 0,
 
     // Cached color-emoji bitmap for the idle indicator (🤖), rasterized via
     // D2D and AlphaBlend'd onto the tab (GDI DrawTextW can't render color
@@ -1078,6 +1086,38 @@ pub const TablineState = struct {
             if (self.agent_states[i] == 2 or self.agent_states[i] == 3) return true;
         }
         return false;
+    }
+
+    /// Queue a completed tab handle + its title (de-duplicated, capped).
+    pub fn pushCompleted(self: *TablineState, handle: i64, title: []const u8) void {
+        var i: usize = 0;
+        while (i < self.agent_completed_count) : (i += 1) {
+            if (self.agent_completed[i] == handle) return;
+        }
+        if (self.agent_completed_count < self.agent_completed.len) {
+            const idx = self.agent_completed_count;
+            self.agent_completed[idx] = handle;
+            const n = @min(title.len, self.agent_completed_titles[idx].len);
+            @memcpy(self.agent_completed_titles[idx][0..n], title[0..n]);
+            self.agent_completed_title_lens[idx] = n;
+            self.agent_completed_count += 1;
+        }
+    }
+
+    /// Basename of a tab's name by handle (term://…/bin/zsh -> "zsh"), or "".
+    pub fn tabName(self: *const TablineState, handle: i64) []const u8 {
+        var i: usize = 0;
+        while (i < self.tab_count) : (i += 1) {
+            if (self.tabs[i].handle == handle) {
+                const full = self.tabs[i].name[0..self.tabs[i].name_len];
+                var last: usize = 0;
+                for (full, 0..) |ch, j| {
+                    if (ch == '/' or ch == '\\') last = j + 1;
+                }
+                return full[last..];
+            }
+        }
+        return "";
     }
 
     pub fn cancelDrag(self: *TablineState) void {

--- a/windows/ui/tabbar.zig
+++ b/windows/ui/tabbar.zig
@@ -1805,11 +1805,17 @@ pub fn onTablineUpdate(
 // the spinner timer + paint (drawTablineContent) render the indicator. Fired
 // on the core RPC thread, so update under app.mu then invalidate on the UI
 // thread (the WM_APP_TABLINE_INVALIDATE handler also reconciles the timer).
-pub fn onAgentStatus(ctx: ?*anyopaque, tab_handle: i64, state: u8) callconv(.c) void {
+pub fn onAgentStatus(ctx: ?*anyopaque, tab_handle: i64, state: u8, title: [*]const u8, title_len: usize) callconv(.c) void {
     const app: *App = @ptrCast(@alignCast(ctx.?));
     {
         app.mu.lock();
         defer app.mu.unlock();
+        // Detect a working(2/3) -> idle(1) transition; queue the tab handle +
+        // the agent's title so the UI thread can fire a completion notification.
+        const prev = app.tabline_state.agentState(tab_handle);
+        if ((prev == 2 or prev == 3) and state == 1) {
+            app.tabline_state.pushCompleted(tab_handle, title[0..title_len]);
+        }
         app.tabline_state.setAgentState(tab_handle, state);
     }
     if (app.hwnd) |main_hwnd| {

--- a/windows/ui/tabbar.zig
+++ b/windows/ui/tabbar.zig
@@ -57,6 +57,26 @@ fn drawIndicatorGlyph(hdc: c.HDC, glyph: []const u8, x: c_int, cell_w: c_int, to
     _ = c.DrawTextW(hdc, &wide, @intCast(n), &r, c.DT_CENTER | c.DT_VCENTER | c.DT_SINGLELINE | c.DT_NOCLIP);
 }
 
+/// Pause glyph (waiting-for-input): two vertical bars in the text color, drawn
+/// as filled rects so it stays crisp without depending on an emoji font.
+fn drawPauseGlyph(hdc: c.HDC, x: c_int, cell_w: c_int, top: c_int, bottom: c_int) void {
+    // Size off cell_w (= ind_px, the robot emoji's footprint), not the full text
+    // rect height, so the pause icon matches the robot's scale rather than dwarfing it.
+    const bar_h = @divTrunc(cell_w * 8, 10);
+    const h = bottom - top;
+    const by = top + @divTrunc(h - bar_h, 2);
+    const bar_w = @max(@as(c_int, 2), @divTrunc(cell_w, 6));
+    const gap = @max(@as(c_int, 2), @divTrunc(cell_w, 6));
+    const total = bar_w * 2 + gap;
+    const bx = x + @divTrunc(cell_w - total, 2);
+    const brush = c.CreateSolidBrush(c.GetTextColor(hdc));
+    defer _ = c.DeleteObject(brush);
+    var r1 = c.RECT{ .left = bx, .top = by, .right = bx + bar_w, .bottom = by + bar_h };
+    _ = c.FillRect(hdc, &r1, brush);
+    var r2 = c.RECT{ .left = bx + bar_w + gap, .top = by, .right = bx + bar_w + gap + bar_w, .bottom = by + bar_h };
+    _ = c.FillRect(hdc, &r2, brush);
+}
+
 // 🤖 (U+1F916 ROBOT FACE) as a UTF-16 surrogate pair, for the idle indicator.
 const agent_emoji_utf16 = [_]c.WCHAR{ 0xD83E, 0xDD16 };
 
@@ -1501,9 +1521,7 @@ pub fn drawTablineContent(app: *App, hdc: c.HDC, client_width: c_int) void {
         // glyph widths never shift the tab title between frames. Idle shows a
         // color 🤖 (AlphaBlend; GDI DrawTextW can't render color emoji);
         // working shows a monochrome spinner glyph centered in the same cell.
-        const a_raw = if (app.config.tabline.agent_indicator) app.tabline_state.agentState(tab.handle) else 0;
-        // Waiting-for-input (4) renders like idle (the robot icon) for now.
-        const a_state: u8 = if (a_raw == 4) 1 else a_raw;
+        const a_state = if (app.config.tabline.agent_indicator) app.tabline_state.agentState(tab.handle) else 0;
         if (a_state != 0) {
             // Indicator cell sized near the text cap height, sitting inline.
             const ind_px = @divTrunc((bar_height - top_padding * 2) * 7, 10);
@@ -1515,6 +1533,9 @@ pub fn drawTablineContent(app: *App, hdc: c.HDC, client_width: c_int) void {
                 } else {
                     drawIndicatorGlyph(hdc, "●", text_rect.left, ind_px, text_rect.top, text_rect.bottom);
                 }
+            } else if (a_state == 4) {
+                // Waiting for user input -> pause glyph (two bars).
+                drawPauseGlyph(hdc, text_rect.left, ind_px, text_rect.top, text_rect.bottom);
             } else {
                 const g = agentSpinnerGlyph(a_state, app.tabline_state.spinner_frame);
                 drawIndicatorGlyph(hdc, g, text_rect.left, ind_px, text_rect.top, text_rect.bottom);

--- a/windows/ui/tabbar.zig
+++ b/windows/ui/tabbar.zig
@@ -1501,7 +1501,7 @@ pub fn drawTablineContent(app: *App, hdc: c.HDC, client_width: c_int) void {
         // glyph widths never shift the tab title between frames. Idle shows a
         // color 🤖 (AlphaBlend; GDI DrawTextW can't render color emoji);
         // working shows a monochrome spinner glyph centered in the same cell.
-        const a_state = app.tabline_state.agentState(tab.handle);
+        const a_state = if (app.config.tabline.agent_indicator) app.tabline_state.agentState(tab.handle) else 0;
         if (a_state != 0) {
             // Indicator cell sized near the text cap height, sitting inline.
             const ind_px = @divTrunc((bar_height - top_padding * 2) * 7, 10);
@@ -1813,7 +1813,7 @@ pub fn onAgentStatus(ctx: ?*anyopaque, tab_handle: i64, state: u8, title: [*]con
         // Detect a working(2/3) -> idle(1) transition; queue the tab handle +
         // the agent's title so the UI thread can fire a completion notification.
         const prev = app.tabline_state.agentState(tab_handle);
-        if ((prev == 2 or prev == 3) and state == 1) {
+        if (app.config.tabline.agent_notification and (prev == 2 or prev == 3) and state == 1) {
             app.tabline_state.pushCompleted(tab_handle, title[0..title_len]);
         }
         app.tabline_state.setAgentState(tab_handle, state);

--- a/windows/ui/tabbar.zig
+++ b/windows/ui/tabbar.zig
@@ -16,15 +16,9 @@ const TabEntry = app_mod.TabEntry;
 /// Returns the length of the display name written to out_buf.
 fn extractTabDisplayName(tab: *const TabEntry, out_buf: *[256]u8) usize {
     if (tab.name_len > 0) {
-        var last_sep: usize = 0;
-        for (0..tab.name_len) |j| {
-            if (tab.name[j] == '/' or tab.name[j] == '\\') {
-                last_sep = j + 1;
-            }
-        }
-        const display_len = tab.name_len - last_sep;
-        @memcpy(out_buf[0..display_len], tab.name[last_sep..tab.name_len]);
-        return display_len;
+        const display = app_mod.baseName(tab.name[0..tab.name_len]);
+        @memcpy(out_buf[0..display.len], display);
+        return display.len;
     } else {
         const no_name = "[No Name]";
         @memcpy(out_buf[0..no_name.len], no_name);

--- a/windows/ui/tabbar.zig
+++ b/windows/ui/tabbar.zig
@@ -1501,7 +1501,9 @@ pub fn drawTablineContent(app: *App, hdc: c.HDC, client_width: c_int) void {
         // glyph widths never shift the tab title between frames. Idle shows a
         // color 🤖 (AlphaBlend; GDI DrawTextW can't render color emoji);
         // working shows a monochrome spinner glyph centered in the same cell.
-        const a_state = if (app.config.tabline.agent_indicator) app.tabline_state.agentState(tab.handle) else 0;
+        const a_raw = if (app.config.tabline.agent_indicator) app.tabline_state.agentState(tab.handle) else 0;
+        // Waiting-for-input (4) renders like idle (the robot icon) for now.
+        const a_state: u8 = if (a_raw == 4) 1 else a_raw;
         if (a_state != 0) {
             // Indicator cell sized near the text cap height, sitting inline.
             const ind_px = @divTrunc((bar_height - top_padding * 2) * 7, 10);
@@ -1810,11 +1812,11 @@ pub fn onAgentStatus(ctx: ?*anyopaque, tab_handle: i64, state: u8, title: [*]con
     {
         app.mu.lock();
         defer app.mu.unlock();
-        // Detect a working(2/3) -> idle(1) transition; queue the tab handle +
-        // the agent's title so the UI thread can fire a completion notification.
+        // working(2/3) -> idle(1) = finished; working -> waiting(4) = paused for
+        // input. Queue either (with the title + which kind) for the UI thread.
         const prev = app.tabline_state.agentState(tab_handle);
-        if (app.config.tabline.agent_notification and (prev == 2 or prev == 3) and state == 1) {
-            app.tabline_state.pushCompleted(tab_handle, title[0..title_len]);
+        if (app.config.tabline.agent_notification and (prev == 2 or prev == 3) and (state == 1 or state == 4)) {
+            app.tabline_state.pushCompleted(tab_handle, title[0..title_len], state == 4);
         }
         app.tabline_state.setAgentState(tab_handle, state);
     }

--- a/windows/ui/tabbar.zig
+++ b/windows/ui/tabbar.zig
@@ -32,22 +32,29 @@ fn extractTabDisplayName(tab: *const TabEntry, out_buf: *[256]u8) usize {
     }
 }
 
-// AI-agent indicator glyphs (with trailing space) drawn before the tab name.
-// Idle uses ● (GDI-safe monochrome; color emoji can't render via DrawTextW).
-// Claude's official thinking sequence is · ✢ ✳ ✶ ✻ ✽ (120ms/frame); Codex and
-// generic agents animate the standard Braille spinner. All are monochrome.
-const agent_claude_frames = [_][]const u8{ "· ", "✢ ", "✳ ", "✶ ", "✻ ", "✽ " };
-const agent_braille_frames = [_][]const u8{ "⠋ ", "⠙ ", "⠹ ", "⠸ ", "⠼ ", "⠴ ", "⠦ ", "⠧ ", "⠇ ", "⠏ " };
+// AI-agent spinner glyphs (single glyph, no trailing space; drawn centered in a
+// fixed-width indicator cell). Claude's official thinking sequence is
+// · ✢ ✳ ✶ ✻ ✽ (120ms/frame); Codex and generic agents animate the standard
+// Braille spinner. All monochrome (GDI-rendered).
+const agent_claude_frames = [_][]const u8{ "·", "✢", "✳", "✶", "✻", "✽" };
+const agent_braille_frames = [_][]const u8{ "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
 
-/// Leading agent glyph (with trailing space) for a tab state+frame, or "".
-/// Used for the working spinner (monochrome, GDI) and the idle text fallback.
-fn agentPrefix(state: u8, frame: u32) []const u8 {
+/// Working spinner glyph for a tab state+frame ("" for non-working states).
+fn agentSpinnerGlyph(state: u8, frame: u32) []const u8 {
     return switch (state) {
-        1 => "● ",
         2 => agent_claude_frames[frame % agent_claude_frames.len],
         3 => agent_braille_frames[frame % agent_braille_frames.len],
         else => "",
     };
+}
+
+/// Draw a single monochrome indicator glyph centered in a fixed-width cell
+/// [x, x+cell_w) so the title (drawn after the cell) never shifts per frame.
+fn drawIndicatorGlyph(hdc: c.HDC, glyph: []const u8, x: c_int, cell_w: c_int, top: c_int, bottom: c_int) void {
+    var wide: [8]u16 = undefined;
+    const n = std.unicode.utf8ToUtf16Le(&wide, glyph) catch return;
+    var r = c.RECT{ .left = x, .top = top, .right = x + cell_w, .bottom = bottom };
+    _ = c.DrawTextW(hdc, &wide, @intCast(n), &r, c.DT_CENTER | c.DT_VCENTER | c.DT_SINGLELINE | c.DT_NOCLIP);
 }
 
 // 🤖 (U+1F916 ROBOT FACE) as a UTF-16 surrogate pair, for the idle indicator.
@@ -1490,37 +1497,36 @@ pub fn drawTablineContent(app: *App, hdc: c.HDC, client_width: c_int) void {
             .bottom = bar_height,
         };
 
-        // AI-agent indicator: idle shows a color 🤖 (AlphaBlend, since GDI
-        // DrawTextW can't render color emoji); working shows a monochrome
-        // spinner glyph as a text prefix. Emoji falls back to "● " text.
+        // AI-agent indicator drawn in a FIXED-WIDTH cell so varying spinner
+        // glyph widths never shift the tab title between frames. Idle shows a
+        // color 🤖 (AlphaBlend; GDI DrawTextW can't render color emoji);
+        // working shows a monochrome spinner glyph centered in the same cell.
         const a_state = app.tabline_state.agentState(tab.handle);
-        var prefix: []const u8 = "";
-        if (a_state == 1) {
-            // Size the emoji near the text cap height, not the full bar, so it
-            // sits visually inline with the tab label and spinner glyphs.
-            const emoji_px = @divTrunc((bar_height - top_padding * 2) * 7, 10);
-            if (if (emoji_px > 0) ensureAgentEmoji(app, emoji_px) else null) |hbm| {
-                const ey = @divTrunc(bar_height - emoji_px, 2);
-                blendAgentEmoji(hdc, hbm, text_rect.left, ey, emoji_px);
-                text_rect.left += emoji_px + top_padding; // reserve emoji + gap
+        if (a_state != 0) {
+            // Indicator cell sized near the text cap height, sitting inline.
+            const ind_px = @divTrunc((bar_height - top_padding * 2) * 7, 10);
+            const cell_w = ind_px + top_padding; // glyph box + gap, reserved
+            if (a_state == 1) {
+                if (if (ind_px > 0) ensureAgentEmoji(app, ind_px) else null) |hbm| {
+                    const ey = @divTrunc(bar_height - ind_px, 2);
+                    blendAgentEmoji(hdc, hbm, text_rect.left, ey, ind_px);
+                } else {
+                    drawIndicatorGlyph(hdc, "●", text_rect.left, ind_px, text_rect.top, text_rect.bottom);
+                }
             } else {
-                prefix = "● ";
+                const g = agentSpinnerGlyph(a_state, app.tabline_state.spinner_frame);
+                drawIndicatorGlyph(hdc, g, text_rect.left, ind_px, text_rect.top, text_rect.bottom);
             }
-        } else if (a_state == 2 or a_state == 3) {
-            prefix = agentPrefix(a_state, app.tabline_state.spinner_frame);
+            text_rect.left += cell_w; // anchor the title past the fixed cell
         }
 
-        // Display name = indicator text prefix + basename.
+        // Display name = basename only (indicator drawn separately above).
         var base_buf: [256]u8 = undefined;
         const base_len = extractTabDisplayName(tab, &base_buf);
-        var display_name: [320]u8 = undefined;
-        @memcpy(display_name[0..prefix.len], prefix);
-        @memcpy(display_name[prefix.len..][0..base_len], base_buf[0..base_len]);
-        const display_len = prefix.len + base_len;
 
         // Convert to wide string
         var wide_buf: [320]u16 = undefined;
-        const wide_len = std.unicode.utf8ToUtf16Le(&wide_buf, display_name[0..display_len]) catch 0;
+        const wide_len = std.unicode.utf8ToUtf16Le(&wide_buf, base_buf[0..base_len]) catch 0;
 
         _ = c.DrawTextW(hdc, &wide_buf, @intCast(wide_len), &text_rect, c.DT_LEFT | c.DT_VCENTER | c.DT_SINGLELINE | c.DT_END_ELLIPSIS);
 

--- a/windows/ui/tabbar.zig
+++ b/windows/ui/tabbar.zig
@@ -40,6 +40,7 @@ const agent_claude_frames = [_][]const u8{ "· ", "✢ ", "✳ ", "✶ ", "✻ "
 const agent_braille_frames = [_][]const u8{ "⠋ ", "⠙ ", "⠹ ", "⠸ ", "⠼ ", "⠴ ", "⠦ ", "⠧ ", "⠇ ", "⠏ " };
 
 /// Leading agent glyph (with trailing space) for a tab state+frame, or "".
+/// Used for the working spinner (monochrome, GDI) and the idle text fallback.
 fn agentPrefix(state: u8, frame: u32) []const u8 {
     return switch (state) {
         1 => "● ",
@@ -47,6 +48,133 @@ fn agentPrefix(state: u8, frame: u32) []const u8 {
         3 => agent_braille_frames[frame % agent_braille_frames.len],
         else => "",
     };
+}
+
+// 🤖 (U+1F916 ROBOT FACE) as a UTF-16 surrogate pair, for the idle indicator.
+const agent_emoji_utf16 = [_]c.WCHAR{ 0xD83E, 0xDD16 };
+
+/// Rasterize 🤖 in color into a px×px premultiplied-BGRA DIBSection via D2D and
+/// return the HBITMAP (caller owns it; freed by ensureAgentEmoji on resize /
+/// App deinit). GDI DrawTextW cannot render color emoji, so we reuse the
+/// renderer's proven CreateDCRenderTarget + DrawTextW(ENABLE_COLOR_FONT) path.
+/// Premultiplied alpha matches AlphaBlend(AC_SRC_ALPHA).
+fn rasterizeAgentEmoji(d2d_factory: *c.ID2D1Factory, dwrite_factory: *c.IDWriteFactory, px: i32) ?c.HBITMAP {
+    if (px <= 0) return null;
+
+    const hdc = c.CreateCompatibleDC(null);
+    if (hdc == null) return null;
+    defer _ = c.DeleteDC(hdc);
+
+    var bmi: c.BITMAPINFO = std.mem.zeroes(c.BITMAPINFO);
+    bmi.bmiHeader.biSize = @sizeOf(c.BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth = px;
+    bmi.bmiHeader.biHeight = -px; // top-down
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = c.BI_RGB;
+
+    var bits: ?*anyopaque = null;
+    const hbm = c.CreateDIBSection(hdc, &bmi, c.DIB_RGB_COLORS, &bits, null, 0);
+    if (hbm == null or bits == null) return null;
+    _ = c.SelectObject(hdc, hbm);
+
+    const ok = blk: {
+        const rtp = c.D2D1_RENDER_TARGET_PROPERTIES{
+            .type = c.D2D1_RENDER_TARGET_TYPE_DEFAULT,
+            .pixelFormat = .{ .format = c.DXGI_FORMAT_B8G8R8A8_UNORM, .alphaMode = c.D2D1_ALPHA_MODE_PREMULTIPLIED },
+            .dpiX = 0,
+            .dpiY = 0,
+            .usage = c.D2D1_RENDER_TARGET_USAGE_NONE,
+            .minLevel = c.D2D1_FEATURE_LEVEL_DEFAULT,
+        };
+        var dc_rt: ?*c.ID2D1DCRenderTarget = null;
+        const create_fn = d2d_factory.lpVtbl.*.CreateDCRenderTarget orelse break :blk false;
+        if (create_fn(d2d_factory, &rtp, &dc_rt) != 0 or dc_rt == null) break :blk false;
+        defer {
+            const u: *c.IUnknown = @ptrCast(dc_rt.?);
+            _ = u.lpVtbl.*.Release.?(u);
+        }
+
+        var bind_rect: c.RECT = .{ .left = 0, .top = 0, .right = px, .bottom = px };
+        const bind_fn = dc_rt.?.lpVtbl.*.BindDC orelse break :blk false;
+        if (bind_fn(dc_rt.?, hdc, &bind_rect) != 0) break :blk false;
+
+        const emoji_font: [*:0]const u16 = std.unicode.utf8ToUtf16LeStringLiteral("Segoe UI Emoji");
+        const font_size: f32 = @as(f32, @floatFromInt(px)) * 0.78;
+        var fmt: ?*c.IDWriteTextFormat = null;
+        const create_tf = dwrite_factory.lpVtbl.*.CreateTextFormat orelse break :blk false;
+        if (create_tf(dwrite_factory, emoji_font, null, c.DWRITE_FONT_WEIGHT_NORMAL, c.DWRITE_FONT_STYLE_NORMAL, c.DWRITE_FONT_STRETCH_NORMAL, font_size, std.unicode.utf8ToUtf16LeStringLiteral("en-us"), &fmt) != 0 or fmt == null) break :blk false;
+        defer {
+            const u: *c.IUnknown = @ptrCast(fmt.?);
+            _ = u.lpVtbl.*.Release.?(u);
+        }
+        if (fmt.?.lpVtbl.*.SetTextAlignment) |f| _ = f(fmt.?, c.DWRITE_TEXT_ALIGNMENT_CENTER);
+        if (fmt.?.lpVtbl.*.SetParagraphAlignment) |f| _ = f(fmt.?, c.DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+
+        const rt_base: *c.ID2D1RenderTarget = @ptrCast(dc_rt.?);
+        const vtbl = rt_base.lpVtbl.*;
+        if (vtbl.BeginDraw) |f| f(rt_base);
+        if (vtbl.Clear) |f| {
+            const transparent = c.D2D1_COLOR_F{ .r = 0, .g = 0, .b = 0, .a = 0 };
+            f(rt_base, &transparent);
+        }
+        var brush: ?*c.ID2D1SolidColorBrush = null;
+        if (vtbl.CreateSolidColorBrush) |f| {
+            const white = c.D2D1_COLOR_F{ .r = 1, .g = 1, .b = 1, .a = 1 };
+            _ = f(rt_base, &white, null, &brush);
+        }
+        defer {
+            if (brush) |b| {
+                const u: *c.IUnknown = @ptrCast(b);
+                _ = u.lpVtbl.*.Release.?(u);
+            }
+        }
+        if (brush) |b| {
+            const layout = c.D2D1_RECT_F{ .left = 0, .top = 0, .right = @floatFromInt(px), .bottom = @floatFromInt(px) };
+            if (vtbl.DrawTextW) |draw_fn| {
+                draw_fn(rt_base, &agent_emoji_utf16, agent_emoji_utf16.len, fmt.?, &layout, @ptrCast(b), c.D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT, c.DWRITE_MEASURING_MODE_NATURAL);
+            }
+        }
+        var t1: u64 = 0;
+        var t2: u64 = 0;
+        if (vtbl.EndDraw) |f| {
+            if (f(rt_base, &t1, &t2) != 0) break :blk false;
+        }
+        break :blk true;
+    };
+
+    if (!ok) {
+        _ = c.DeleteObject(hbm);
+        return null;
+    }
+    return hbm;
+}
+
+/// Cached 🤖 bitmap at the requested square size; re-rasterizes on size change.
+fn ensureAgentEmoji(app: *App, px: i32) ?c.HBITMAP {
+    if (app.tabline_state.agent_emoji_hbm) |hbm| {
+        if (app.tabline_state.agent_emoji_px == px) return hbm;
+        _ = c.DeleteObject(hbm);
+        app.tabline_state.agent_emoji_hbm = null;
+    }
+    const r = if (app.atlas) |*rr| rr else return null;
+    const d2d = r.d2d_factory orelse return null;
+    const dw = r.dwrite_factory orelse return null;
+    const hbm = rasterizeAgentEmoji(d2d, dw, px) orelse return null;
+    app.tabline_state.agent_emoji_hbm = hbm;
+    app.tabline_state.agent_emoji_px = px;
+    return hbm;
+}
+
+/// AlphaBlend the cached premultiplied 🤖 bitmap onto the tabline DC.
+fn blendAgentEmoji(dst_hdc: c.HDC, hbm: c.HBITMAP, x: i32, y: i32, px: i32) void {
+    const mem = c.CreateCompatibleDC(dst_hdc);
+    if (mem == null) return;
+    defer _ = c.DeleteDC(mem);
+    const old = c.SelectObject(mem, hbm);
+    defer _ = c.SelectObject(mem, old);
+    const bf = c.BLENDFUNCTION{ .BlendOp = c.AC_SRC_OVER, .BlendFlags = 0, .SourceConstantAlpha = 255, .AlphaFormat = c.AC_SRC_ALPHA };
+    _ = c.AlphaBlend(dst_hdc, x, y, px, px, mem, 0, 0, px, px, bf);
 }
 
 /// Calculate the Neovim :tabmove position from a drop target index.
@@ -1362,10 +1490,27 @@ pub fn drawTablineContent(app: *App, hdc: c.HDC, client_width: c_int) void {
             .bottom = bar_height,
         };
 
-        // Display name = AI-agent indicator glyph (state+frame) + basename.
+        // AI-agent indicator: idle shows a color 🤖 (AlphaBlend, since GDI
+        // DrawTextW can't render color emoji); working shows a monochrome
+        // spinner glyph as a text prefix. Emoji falls back to "● " text.
+        const a_state = app.tabline_state.agentState(tab.handle);
+        var prefix: []const u8 = "";
+        if (a_state == 1) {
+            const emoji_px = bar_height - top_padding * 2;
+            if (if (emoji_px > 0) ensureAgentEmoji(app, emoji_px) else null) |hbm| {
+                const ey = @divTrunc(bar_height - emoji_px, 2);
+                blendAgentEmoji(hdc, hbm, text_rect.left, ey, emoji_px);
+                text_rect.left += emoji_px + top_padding; // reserve emoji + gap
+            } else {
+                prefix = "● ";
+            }
+        } else if (a_state == 2 or a_state == 3) {
+            prefix = agentPrefix(a_state, app.tabline_state.spinner_frame);
+        }
+
+        // Display name = indicator text prefix + basename.
         var base_buf: [256]u8 = undefined;
         const base_len = extractTabDisplayName(tab, &base_buf);
-        const prefix = agentPrefix(app.tabline_state.agentState(tab.handle), app.tabline_state.spinner_frame);
         var display_name: [320]u8 = undefined;
         @memcpy(display_name[0..prefix.len], prefix);
         @memcpy(display_name[prefix.len..][0..base_len], base_buf[0..base_len]);

--- a/windows/ui/tabbar.zig
+++ b/windows/ui/tabbar.zig
@@ -32,6 +32,23 @@ fn extractTabDisplayName(tab: *const TabEntry, out_buf: *[256]u8) usize {
     }
 }
 
+// AI-agent indicator glyphs (with trailing space) drawn before the tab name.
+// Idle uses ● (GDI-safe monochrome; color emoji can't render via DrawTextW).
+// Claude's official thinking sequence is · ✢ ✳ ✶ ✻ ✽ (120ms/frame); Codex and
+// generic agents animate the standard Braille spinner. All are monochrome.
+const agent_claude_frames = [_][]const u8{ "· ", "✢ ", "✳ ", "✶ ", "✻ ", "✽ " };
+const agent_braille_frames = [_][]const u8{ "⠋ ", "⠙ ", "⠹ ", "⠸ ", "⠼ ", "⠴ ", "⠦ ", "⠧ ", "⠇ ", "⠏ " };
+
+/// Leading agent glyph (with trailing space) for a tab state+frame, or "".
+fn agentPrefix(state: u8, frame: u32) []const u8 {
+    return switch (state) {
+        1 => "● ",
+        2 => agent_claude_frames[frame % agent_claude_frames.len],
+        3 => agent_braille_frames[frame % agent_braille_frames.len],
+        else => "",
+    };
+}
+
 /// Calculate the Neovim :tabmove position from a drop target index.
 /// Returns the value N for `:tabmove N`.
 fn calculateTabMovePosition(to_idx: usize, tab_count: usize) i32 {
@@ -1068,17 +1085,9 @@ pub fn dragPreviewWndProc(hwnd: c.HWND, msg: c.UINT, wParam: c.WPARAM, lParam: c
                         if (drag_idx < app.tabline_state.tab_count) {
                             const tab = &app.tabline_state.tabs[drag_idx];
                             if (tab.name_len > 0) {
-                                // Get just the filename
-                                var display_name: []const u8 = tab.name[0..tab.name_len];
-                                var last_sep: usize = 0;
-                                for (display_name, 0..) |ch, i| {
-                                    if (ch == '/' or ch == '\\') {
-                                        last_sep = i + 1;
-                                    }
-                                }
-                                if (last_sep < display_name.len) {
-                                    display_name = display_name[last_sep..];
-                                }
+                                // Display name (basename, preserving the agent-status glyph).
+                                var name_buf: [256]u8 = undefined;
+                                const display_name = name_buf[0..extractTabDisplayName(tab, &name_buf)];
 
                                 // Draw text
                                 var text_rect = rect;
@@ -1353,12 +1362,17 @@ pub fn drawTablineContent(app: *App, hdc: c.HDC, client_width: c_int) void {
             .bottom = bar_height,
         };
 
-        // Convert name to display
-        var display_name: [256]u8 = undefined;
-        const display_len = extractTabDisplayName(tab, &display_name);
+        // Display name = AI-agent indicator glyph (state+frame) + basename.
+        var base_buf: [256]u8 = undefined;
+        const base_len = extractTabDisplayName(tab, &base_buf);
+        const prefix = agentPrefix(app.tabline_state.agentState(tab.handle), app.tabline_state.spinner_frame);
+        var display_name: [320]u8 = undefined;
+        @memcpy(display_name[0..prefix.len], prefix);
+        @memcpy(display_name[prefix.len..][0..base_len], base_buf[0..base_len]);
+        const display_len = prefix.len + base_len;
 
         // Convert to wide string
-        var wide_buf: [256]u16 = undefined;
+        var wide_buf: [320]u16 = undefined;
         const wide_len = std.unicode.utf8ToUtf16Le(&wide_buf, display_name[0..display_len]) catch 0;
 
         _ = c.DrawTextW(hdc, &wide_buf, @intCast(wide_len), &text_rect, c.DT_LEFT | c.DT_VCENTER | c.DT_SINGLELINE | c.DT_END_ELLIPSIS);
@@ -1629,6 +1643,22 @@ pub fn onTablineUpdate(
 
     // Request repaint via PostMessage to UI thread
     // Tabline is now drawn on parent window, so invalidate parent
+    if (app.hwnd) |main_hwnd| {
+        _ = c.PostMessageW(main_hwnd, app_mod.WM_APP_TABLINE_INVALIDATE, 0, 0);
+    }
+}
+
+// AI-agent work state for a tab (from on_agent_status). Stored per handle;
+// the spinner timer + paint (drawTablineContent) render the indicator. Fired
+// on the core RPC thread, so update under app.mu then invalidate on the UI
+// thread (the WM_APP_TABLINE_INVALIDATE handler also reconciles the timer).
+pub fn onAgentStatus(ctx: ?*anyopaque, tab_handle: i64, state: u8) callconv(.c) void {
+    const app: *App = @ptrCast(@alignCast(ctx.?));
+    {
+        app.mu.lock();
+        defer app.mu.unlock();
+        app.tabline_state.setAgentState(tab_handle, state);
+    }
     if (app.hwnd) |main_hwnd| {
         _ = c.PostMessageW(main_hwnd, app_mod.WM_APP_TABLINE_INVALIDATE, 0, 0);
     }

--- a/windows/ui/tabbar.zig
+++ b/windows/ui/tabbar.zig
@@ -1496,7 +1496,9 @@ pub fn drawTablineContent(app: *App, hdc: c.HDC, client_width: c_int) void {
         const a_state = app.tabline_state.agentState(tab.handle);
         var prefix: []const u8 = "";
         if (a_state == 1) {
-            const emoji_px = bar_height - top_padding * 2;
+            // Size the emoji near the text cap height, not the full bar, so it
+            // sits visually inline with the tab label and spinner glyphs.
+            const emoji_px = @divTrunc((bar_height - top_padding * 2) * 7, 10);
             if (if (emoji_px > 0) ensureAgentEmoji(app, emoji_px) else null) |hbm| {
                 const ey = @divTrunc(bar_height - emoji_px, 2);
                 blendAgentEmoji(hdc, hbm, text_rect.left, ey, emoji_px);

--- a/windows/window.zig
+++ b/windows/window.zig
@@ -2897,8 +2897,13 @@ pub export fn WndProc(
                                     app.tabline_state.agent_completed_titles[0][0..tlen]
                                 else
                                     app.tabline_state.tabName(app.tabline_state.agent_completed[0]);
+                                const waiting = app.tabline_state.agent_completed_waiting[0];
+                                const label = if (waiting) "Needs input" else "Finished";
+                                const fallback = if (waiting) "AI agent needs input" else "AI agent finished";
                                 if (summary.len > 0) {
-                                    bmsg = std.fmt.bufPrint(&msg_buf, "Finished: {s}", .{summary}) catch "AI agent finished";
+                                    bmsg = std.fmt.bufPrint(&msg_buf, "{s}: {s}", .{ label, summary }) catch fallback;
+                                } else {
+                                    bmsg = fallback;
                                 }
                             } else {
                                 bmsg = std.fmt.bufPrint(&msg_buf, "{d} AI agents finished", .{app.tabline_state.agent_completed_count}) catch "AI agents finished";

--- a/windows/window.zig
+++ b/windows/window.zig
@@ -2863,6 +2863,7 @@ pub export fn WndProc(
                 // Start/stop the agent spinner animation timer to match whether
                 // any tab is currently working (idle/none need no animation).
                 const working = blk: {
+                    if (!app.config.tabline.agent_indicator) break :blk false;
                     app.mu.lock();
                     defer app.mu.unlock();
                     break :blk app.tabline_state.anyAgentWorking();

--- a/windows/window.zig
+++ b/windows/window.zig
@@ -2874,6 +2874,40 @@ pub export fn WndProc(
                     _ = c.KillTimer(hwnd, app_mod.TIMER_AGENT_SPINNER);
                     app.tabline_state.spinner_timer_active = false;
                 }
+                // Drain queued agent completions into a per-tab OS notification.
+                // Always notify (window-level focus suppression doesn't fit
+                // running the agent inside zonvie's own terminal). Keep the queue
+                // if the tray isn't ready yet (startup race).
+                const n_completed = blk: {
+                    app.mu.lock();
+                    defer app.mu.unlock();
+                    break :blk app.tabline_state.agent_completed_count;
+                };
+                if (n_completed > 0) {
+                    if (app.tray_icon) |*tray| {
+                        var msg_buf: [320]u8 = undefined;
+                        var bmsg: []const u8 = "AI agent finished";
+                        {
+                            app.mu.lock();
+                            defer app.mu.unlock();
+                            if (app.tabline_state.agent_completed_count == 1) {
+                                const tlen = app.tabline_state.agent_completed_title_lens[0];
+                                const summary = if (tlen > 0)
+                                    app.tabline_state.agent_completed_titles[0][0..tlen]
+                                else
+                                    app.tabline_state.tabName(app.tabline_state.agent_completed[0]);
+                                if (summary.len > 0) {
+                                    bmsg = std.fmt.bufPrint(&msg_buf, "Finished: {s}", .{summary}) catch "AI agent finished";
+                                }
+                            } else {
+                                bmsg = std.fmt.bufPrint(&msg_buf, "{d} AI agents finished", .{app.tabline_state.agent_completed_count}) catch "AI agents finished";
+                            }
+                            app.tabline_state.agent_completed_count = 0;
+                        }
+                        tray.showBalloon("Zonvie", bmsg);
+                    }
+                    // else: tray not ready — keep the queue for a later drain.
+                }
                 // Tabline is rendered as D3D11 texture via renderTablineToD3D
                 // Invalidate main window to trigger WM_PAINT which calls renderTablineToD3D
                 _ = c.InvalidateRect(hwnd, null, 0);

--- a/windows/window.zig
+++ b/windows/window.zig
@@ -2906,7 +2906,22 @@ pub export fn WndProc(
                                     bmsg = fallback;
                                 }
                             } else {
-                                bmsg = std.fmt.bufPrint(&msg_buf, "{d} AI agents finished", .{app.tabline_state.agent_completed_count}) catch "AI agents finished";
+                                // Multiple completions drained together: some may be
+                                // "waiting for input" rather than finished. Count them
+                                // so the message doesn't falsely claim work is done.
+                                const total = app.tabline_state.agent_completed_count;
+                                var waiting_n: usize = 0;
+                                var wi: usize = 0;
+                                while (wi < total) : (wi += 1) {
+                                    if (app.tabline_state.agent_completed_waiting[wi]) waiting_n += 1;
+                                }
+                                if (waiting_n == total) {
+                                    bmsg = std.fmt.bufPrint(&msg_buf, "{d} AI agents need input", .{total}) catch "AI agents need input";
+                                } else if (waiting_n > 0) {
+                                    bmsg = std.fmt.bufPrint(&msg_buf, "{d} finished, {d} need input", .{ total - waiting_n, waiting_n }) catch "AI agents finished";
+                                } else {
+                                    bmsg = std.fmt.bufPrint(&msg_buf, "{d} AI agents finished", .{total}) catch "AI agents finished";
+                                }
                             }
                             app.tabline_state.agent_completed_count = 0;
                         }
@@ -3079,10 +3094,20 @@ pub export fn WndProc(
                     input.handleCursorBlinkTimer(hwnd, app);
                 }
             } else if (wParam == app_mod.TIMER_AGENT_SPINNER) {
-                // Advance the AI-agent spinner frame and repaint the tabline.
+                // Advance the AI-agent spinner frame and repaint only the tabline.
+                // Invalidating the whole window would re-present the entire grid at
+                // the spinner rate (~8 Hz) even when the content is static; bound
+                // the dirty region to the tabline strip instead (matches the hover
+                // redraw path).
                 if (getApp(hwnd)) |app| {
                     app.tabline_state.spinner_frame +%= 1;
-                    _ = c.InvalidateRect(hwnd, null, 0);
+                    var tabline_rect: c.RECT = .{
+                        .left = 0,
+                        .top = 0,
+                        .right = 4096,
+                        .bottom = app.scalePx(TablineState.TAB_BAR_HEIGHT),
+                    };
+                    _ = c.InvalidateRect(hwnd, &tabline_rect, 0);
                 }
             } else if (wParam == app_mod.TIMER_CUSTOM_SHADER_ANIM) {
                 // Continuous-redraw tick for animated custom shaders.

--- a/windows/window.zig
+++ b/windows/window.zig
@@ -502,6 +502,7 @@ fn makeCoreCbs() core.Callbacks {
         .on_msg_history_show = messages.onMsgHistoryShow,
         .on_tabline_update = tabline_mod.onTablineUpdate,
         .on_tabline_hide = tabline_mod.onTablineHide,
+        .on_agent_status = tabline_mod.onAgentStatus,
         .on_clipboard_get = callbacks.onClipboardGet,
         .on_clipboard_set = callbacks.onClipboardSet,
         .on_ssh_auth_prompt = callbacks.onSSHAuthPrompt,
@@ -2859,12 +2860,25 @@ pub export fn WndProc(
 
         WM_APP_TABLINE_INVALIDATE => {
             if (getApp(hwnd)) |app| {
+                // Start/stop the agent spinner animation timer to match whether
+                // any tab is currently working (idle/none need no animation).
+                const working = blk: {
+                    app.mu.lock();
+                    defer app.mu.unlock();
+                    break :blk app.tabline_state.anyAgentWorking();
+                };
+                if (working and !app.tabline_state.spinner_timer_active) {
+                    _ = c.SetTimer(hwnd, app_mod.TIMER_AGENT_SPINNER, app_mod.AGENT_SPINNER_INTERVAL_MS, null);
+                    app.tabline_state.spinner_timer_active = true;
+                } else if (!working and app.tabline_state.spinner_timer_active) {
+                    _ = c.KillTimer(hwnd, app_mod.TIMER_AGENT_SPINNER);
+                    app.tabline_state.spinner_timer_active = false;
+                }
                 // Tabline is rendered as D3D11 texture via renderTablineToD3D
                 // Invalidate main window to trigger WM_PAINT which calls renderTablineToD3D
                 _ = c.InvalidateRect(hwnd, null, 0);
                 // Force immediate repaint so tabline updates without waiting for next message
                 _ = c.UpdateWindow(hwnd);
-                _ = app;
             }
             return 0;
         },
@@ -3023,6 +3037,12 @@ pub export fn WndProc(
                 if (applog.isEnabled()) applog.appLog("[win] WM_TIMER: cursor blink\n", .{});
                 if (getApp(hwnd)) |app| {
                     input.handleCursorBlinkTimer(hwnd, app);
+                }
+            } else if (wParam == app_mod.TIMER_AGENT_SPINNER) {
+                // Advance the AI-agent spinner frame and repaint the tabline.
+                if (getApp(hwnd)) |app| {
+                    app.tabline_state.spinner_frame +%= 1;
+                    _ = c.InvalidateRect(hwnd, null, 0);
                 }
             } else if (wParam == app_mod.TIMER_CUSTOM_SHADER_ANIM) {
                 // Continuous-redraw tick for animated custom shaders.


### PR DESCRIPTION
Show whether Claude Code / Codex running in a :terminal is present/idle or thinking, as a glyph on the ext_tabline tab: idle = robot emoji (macOS) / dot (Windows; GDI cannot render color emoji), and an animated spinner while working (Claude's official 6-frame sequence at 120ms; Braille spinner for Codex/generic).

Mechanism: an auto-injected Lua reporter derives per-tab state (0=none/1=idle/2=working-claude/3=working-braille) from each terminal's OSC title (presence and agent-kind latched per buffer; agent exit detected via an empty-title poll since Claude does not reset its title on exit) and broadcasts zonvie_agent_status. A new additive on_agent_status C ABI callback forwards state to the frontends, which own rendering and the spinner animation timer (NSTimer on macOS, SetTimer on Windows). No user configuration required.

macOS verified on real hardware; Windows implemented and compiles but not yet verified on a Windows host.