### PR TITLE
feat(messages): hold the message auto-hide while the pointer is on the float

### DIFF
--- a/include/zonvie_core.h
+++ b/include/zonvie_core.h
@@ -907,6 +907,14 @@ int64_t zonvie_core_next_msg_timeout_ms(zonvie_core *core);
  * its timer for a short fixed retry instead of trusting a stale value. */
 int64_t zonvie_core_try_next_msg_timeout_ms(zonvie_core *core);
 
+/* Report whether the pointer rests on a message ext_float window (grid -102 or
+ * -103; any other grid_id is ignored). While hovered the view's auto-hide
+ * countdown is stopped -- the user is reading it, or reaching for its copy
+ * button -- and leaving restarts it at full length.
+ * Both transitions move the earliest pending deadline, so the caller must
+ * re-arm its one-shot timer from zonvie_core_next_msg_timeout_ms afterwards. */
+void zonvie_core_set_msg_hover(zonvie_core *core, int64_t grid_id, int hovered);
+
 /* Enable blur transparency for background (macOS only).
  * When enabled, default background uses semi-transparent alpha for blur effect.
  * Windows should NOT enable this (causes rendering artifacts). */

--- a/macos/Sources/Core/ZonvieCore.swift
+++ b/macos/Sources/Core/ZonvieCore.swift
@@ -1368,6 +1368,27 @@ final class ZonvieCore {
         zonvie_core_tick_msg_throttle(core)
     }
 
+    /// Report pointer enter/exit on a message ext_float window so the core can
+    /// hold its auto-hide countdown while the user reads the message or reaches
+    /// for the copy button.
+    ///
+    /// Deliberately async even though it is already on the main thread: the
+    /// call takes the core's grid lock, and AppKit can drive a tracking-area
+    /// update from inside a core callback that already holds it
+    /// (zonvie_core_tick_msg_throttle fires on_external_window_close and
+    /// on_msg_clear on this thread with the lock held). Hopping to the next
+    /// runloop turn keeps that from self-deadlocking; the queue preserves
+    /// enter/exit order.
+    func setMsgHover(gridId: Int64, hovered: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let core = self.core else { return }
+            zonvie_core_set_msg_hover(core, gridId, hovered ? 1 : 0)
+            // Pausing or resuming moved the earliest deadline, so the one-shot
+            // timer armed for the old one has to be re-armed.
+            self.terminalView?.scheduleMsgTimer()
+        }
+    }
+
     /// Milliseconds until the core's earliest pending msg_show/msg_history
     /// timeout (throttle or auto-hide), clamped to >= 0. Returns -1 if no
     /// timeout is armed. Used to schedule a one-shot tick instead of polling.
@@ -4091,6 +4112,55 @@ final class ZonvieCore {
         override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
     }
 
+    /// Content view of the decorated message windows (msg_show / msg_history).
+    ///
+    /// Reports pointer enter/exit so the core can hold the view's auto-hide
+    /// countdown while the user reads the message or reaches for the copy
+    /// button. The tracking area covers the whole container, so moving onto the
+    /// copy button — a subview with its own tracking area — is not an exit.
+    final class MsgHoverContainerView: NSView {
+        var onHoverChange: ((Bool) -> Void)?
+        private var hoverTrackingArea: NSTrackingArea?
+
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            if let hoverTrackingArea {
+                removeTrackingArea(hoverTrackingArea)
+            }
+            // .activeAlways for the same reason as CopyContentButton: these
+            // windows never become key.
+            let area = NSTrackingArea(
+                rect: .zero,
+                options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+                owner: self
+            )
+            addTrackingArea(area)
+            hoverTrackingArea = area
+            reportPointerIfInside()
+        }
+
+        override func mouseEntered(with event: NSEvent) {
+            onHoverChange?(true)
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            onHoverChange?(false)
+        }
+
+        /// AppKit posts no mouseEntered for an area installed under a pointer
+        /// that never moves, and a message float routinely appears right under
+        /// one. Without this the countdown would run while the user is already
+        /// on the window. Only entry is reported: the core drops the flag
+        /// itself when the view hides.
+        private func reportPointerIfInside() {
+            guard let window else { return }
+            let pointInView = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+            if bounds.contains(pointInView) {
+                onHoverChange?(true)
+            }
+        }
+    }
+
     /// Content view of the decorated cmdline window.
     ///
     /// AppKit resolves a drag destination by hit-testing and then walking UP
@@ -6233,6 +6303,12 @@ final class ZonvieCore {
             dropContainer.dropTarget = gridView
             dropContainer.registerForDraggedTypes([.fileURL])
             containerView = dropContainer
+        } else if kind == .msgShow || kind == .msgHistory {
+            let hoverContainer = MsgHoverContainerView(frame: containerFrame)
+            hoverContainer.onHoverChange = { [weak self] hovered in
+                self?.setMsgHover(gridId: gridId, hovered: hovered)
+            }
+            containerView = hoverContainer
         } else {
             containerView = NSView(frame: containerFrame)
         }

--- a/src/core/c_api.zig
+++ b/src/core/c_api.zig
@@ -1326,6 +1326,26 @@ pub export fn zonvie_core_try_next_msg_timeout_ms(p: ?*zonvie_core) callconv(.c)
     return @intCast(remaining_ms);
 }
 
+/// Report whether the pointer rests on a message ext_float window. While
+/// hovered the view's auto-hide countdown is stopped — the user is reading it,
+/// or reaching for its copy button — and leaving restarts it at full length.
+/// Ignores any grid that is not a message float.
+///
+/// Both transitions change the earliest pending deadline, so the caller must
+/// re-arm its one-shot timer from zonvie_core_next_msg_timeout_ms afterwards.
+pub export fn zonvie_core_set_msg_hover(p: ?*zonvie_core, grid_id: i64, hovered: i32) callconv(.c) void {
+    if (p == null) return;
+    const box = asBox(p.?);
+    const ch: flush_mod.MsgChannel = switch (grid_id) {
+        grid_mod.MESSAGE_GRID_ID => .show,
+        grid_mod.MSG_HISTORY_GRID_ID => .history,
+        else => return,
+    };
+    box.core.grid_mu.lockUncancelable(clock.io());
+    defer box.core.grid_mu.unlock(clock.io());
+    flush_mod.setChannelHover(&box.core, ch, hovered != 0);
+}
+
 pub export fn zonvie_core_set_blur_enabled(p: ?*zonvie_core, enabled: i32) callconv(.c) void {
     if (p == null) return;
     const box = asBox(p.?);

--- a/src/core/flush.zig
+++ b/src/core/flush.zig
@@ -8964,6 +8964,20 @@ fn channelAutoHideSlot(self: *Core, ch: MsgChannel) *?i128 {
     };
 }
 
+fn channelAutoHideNsSlot(self: *Core, ch: MsgChannel) *?i128 {
+    return switch (ch) {
+        .show => &self.msg_show_auto_hide_ns,
+        .history => &self.msg_history_auto_hide_ns,
+    };
+}
+
+fn channelHoverSlot(self: *Core, ch: MsgChannel) *bool {
+    return switch (ch) {
+        .show => &self.msg_show_hovered,
+        .history => &self.msg_history_hovered,
+    };
+}
+
 /// Run one display cycle for a channel: show every view holding content,
 /// hide every empty view the core still owns. Returns false when the flush
 /// must be retried.
@@ -9023,8 +9037,13 @@ fn showChannelView(self: *Core, ch: MsgChannel, view: config.MsgViewType, conten
                 },
             }
             // timeout=0 means no auto-hide, e.g. errors.
-            channelAutoHideSlot(self, ch).* = if (messageTimeoutNs(state.timeout)) |ns|
-                clock.nowNs() + ns
+            const timeout_ns = messageTimeoutNs(state.timeout);
+            channelAutoHideNsSlot(self, ch).* = timeout_ns;
+            // A message can land on a float the pointer is already resting on.
+            // Arming it there would hide the view mid-read; the pointer leaving
+            // starts the countdown instead.
+            channelAutoHideSlot(self, ch).* = if (timeout_ns) |ns|
+                (if (channelHoverSlot(self, ch).*) null else clock.nowNs() + ns)
             else
                 null;
         },
@@ -9134,6 +9153,11 @@ pub fn hideChannelView(self: *Core, ch: MsgChannel, view: config.MsgViewType) vo
             .history => hideMsgHistory(self),
         }
         channelAutoHideSlot(self, ch).* = null;
+        channelAutoHideNsSlot(self, ch).* = null;
+        // The window can close under a stationary pointer, and AppKit/Win32
+        // deliver no leave event for a window that is gone. Dropping the flag
+        // here keeps a stale hover from suppressing the next view's countdown.
+        channelHoverSlot(self, ch).* = false;
     }
     channelViews(self, ch).markHidden(view);
 }
@@ -9377,6 +9401,29 @@ pub fn pauseChannelAutoHide(self: *Core, ch: MsgChannel) void {
         self.log.write("[msg] channel={s}: auto-hide paused (user interaction)\n", .{@tagName(ch)});
         channelAutoHideSlot(self, ch).* = null;
     }
+}
+
+/// Restart a paused countdown at full length. Unlike the scroll pause, hover
+/// has a defined end, so the pointer leaving resumes the view rather than
+/// waiting for the next show cycle. Only a view the core still shows, and whose
+/// timeout was non-zero, is re-armed.
+fn resumeChannelAutoHide(self: *Core, ch: MsgChannel) void {
+    if (!channelViews(self, ch).state(.ext_float).visible) return;
+    const slot = channelAutoHideSlot(self, ch);
+    if (slot.* != null) return;
+    const ns = channelAutoHideNsSlot(self, ch).* orelse return;
+    slot.* = clock.nowNs() + ns;
+    self.log.write("[msg] channel={s}: auto-hide resumed (hover ended)\n", .{@tagName(ch)});
+}
+
+/// Frontend hover state for a channel's ext_float window. Entering stops the
+/// countdown, leaving restarts it at full length.
+/// IMPORTANT: Caller must hold grid_mu (via the c_api entry point).
+pub fn setChannelHover(self: *Core, ch: MsgChannel, hovered: bool) void {
+    const slot = channelHoverSlot(self, ch);
+    if (slot.* == hovered) return;
+    slot.* = hovered;
+    if (hovered) pauseChannelAutoHide(self, ch) else resumeChannelAutoHide(self, ch);
 }
 
 pub fn handleMsgGridScroll(self: *Core, direction: []const u8) void {
@@ -13821,6 +13868,102 @@ test "scrolling the message float pauses its auto-hide" {
     try std.testing.expect(core.msg_show_auto_hide_at == null);
     try std.testing.expect(core.msg_views.state(.ext_float).visible);
     try std.testing.expect(core.grid.external_grids.contains(grid_mod.MESSAGE_GRID_ID));
+}
+
+test "hovering the message float pauses its auto-hide" {
+    // Same reasoning as the scroll pause: the pointer resting on the float is
+    // the user reading it, or reaching for the copy button. The countdown must
+    // stop, and the float must stay visible.
+    var core = Core.initForTest(std.testing.allocator);
+    defer core.deinitForTest();
+    core.ext_messages_enabled = true;
+
+    try appendTestMessage(&core, 1, "echo", "readable");
+    _ = sendMsgShow(&core);
+    try std.testing.expect(core.msg_show_auto_hide_at != null);
+
+    setChannelHover(&core, .show, true);
+
+    try std.testing.expect(core.msg_show_auto_hide_at == null);
+    try std.testing.expect(core.msg_views.state(.ext_float).visible);
+}
+
+test "leaving the message float re-arms the full timeout" {
+    // Unlike the scroll pause, hover is a state with a defined end: the pointer
+    // leaving restarts the countdown at full length rather than waiting for the
+    // next show cycle.
+    var core = Core.initForTest(std.testing.allocator);
+    defer core.deinitForTest();
+    core.ext_messages_enabled = true;
+
+    try appendTestMessage(&core, 1, "echo", "readable");
+    _ = sendMsgShow(&core);
+    const armed_at = core.msg_show_auto_hide_at.?;
+
+    setChannelHover(&core, .show, true);
+    setChannelHover(&core, .show, false);
+
+    // Full length, not the remainder: the resumed deadline is no earlier than
+    // the original one.
+    const resumed_at = core.msg_show_auto_hide_at orelse return error.NotReArmed;
+    try std.testing.expect(resumed_at >= armed_at);
+}
+
+test "a message shown while hovered does not arm its auto-hide" {
+    // A new message can land on a float the pointer is already over. Arming it
+    // would hide the float mid-read, which is exactly what hover prevents.
+    var core = Core.initForTest(std.testing.allocator);
+    defer core.deinitForTest();
+    core.ext_messages_enabled = true;
+
+    try appendTestMessage(&core, 1, "echo", "first");
+    _ = sendMsgShow(&core);
+    setChannelHover(&core, .show, true);
+
+    try appendTestMessage(&core, 2, "echo", "second");
+    _ = sendMsgShow(&core);
+
+    try std.testing.expect(core.msg_show_auto_hide_at == null);
+    try std.testing.expect(core.msg_views.state(.ext_float).visible);
+}
+
+test "leaving a hidden message float does not resurrect its deadline" {
+    // The window can close under a stationary pointer (msg_clear, auto-hide),
+    // and the frontend's exit event arrives afterwards. Resume must not re-arm
+    // a view the core no longer shows, or nextMsgTimeoutNs would wake forever.
+    var core = Core.initForTest(std.testing.allocator);
+    defer core.deinitForTest();
+    core.ext_messages_enabled = true;
+
+    try appendTestMessage(&core, 1, "echo", "readable");
+    _ = sendMsgShow(&core);
+    setChannelHover(&core, .show, true);
+
+    core.grid.message_state.clearMessages(core.grid.alloc);
+    hideChannelView(&core, .show, .ext_float);
+
+    setChannelHover(&core, .show, false);
+
+    try std.testing.expect(core.msg_show_auto_hide_at == null);
+}
+
+test "a zero-timeout message stays un-armed across a hover cycle" {
+    // timeout=0 means "no auto-hide" (errors). Resume must respect that rather
+    // than inventing a countdown for a message that should persist.
+    var core = Core.initForTest(std.testing.allocator);
+    defer core.deinitForTest();
+    core.ext_messages_enabled = true;
+
+    try appendTestMessage(&core, 1, "echo", "sticky");
+    _ = sendMsgShow(&core);
+    // Emulate a route whose view timeout is 0 by clearing what the show armed.
+    core.msg_show_auto_hide_at = null;
+    core.msg_show_auto_hide_ns = null;
+
+    setChannelHover(&core, .show, true);
+    setChannelHover(&core, .show, false);
+
+    try std.testing.expect(core.msg_show_auto_hide_at == null);
 }
 
 test "hiding the history grid drops its retry deadline" {

--- a/src/core/nvim_core.zig
+++ b/src/core/nvim_core.zig
@@ -919,6 +919,18 @@ pub const Core = struct {
     msg_show_auto_hide_at: ?i128 = null, // grid -102 auto-hide deadline
     msg_history_auto_hide_at: ?i128 = null, // grid -103 auto-hide deadline
 
+    // Auto-hide length of the currently shown view (nanos), kept so a hover
+    // pause can restart the countdown at full length instead of waiting for
+    // the next show cycle. null mirrors "no auto-hide" (timeout=0).
+    msg_show_auto_hide_ns: ?i128 = null,
+    msg_history_auto_hide_ns: ?i128 = null,
+
+    // Pointer resting on the channel's ext_float window. While set, the view
+    // never arms an auto-hide deadline: the user is reading it, or reaching
+    // for its copy button.
+    msg_show_hovered: bool = false,
+    msg_history_hovered: bool = false,
+
     // Scroll state for msg_show ext-float (Zonvie's own grid)
     msg_scroll_offset: u32 = 0, // Current scroll offset (lines from top)
     msg_total_lines: u32 = 0, // Total line count in current message content

--- a/windows/app.zig
+++ b/windows/app.zig
@@ -67,6 +67,7 @@ pub const zonvie_core_set_ext_messages = core.zonvie_core_set_ext_messages;
 pub const zonvie_core_set_ext_tabline = core.zonvie_core_set_ext_tabline;
 pub const zonvie_core_tick_msg_throttle = core.zonvie_core_tick_msg_throttle;
 pub const zonvie_core_try_next_msg_timeout_ms = core.zonvie_core_try_next_msg_timeout_ms;
+pub const zonvie_core_set_msg_hover = core.zonvie_core_set_msg_hover;
 pub const zonvie_core_set_blur_enabled = core.zonvie_core_set_blur_enabled;
 pub const zonvie_core_set_inherit_cwd = core.zonvie_core_set_inherit_cwd;
 pub const zonvie_core_set_glyph_cache_size = core.zonvie_core_set_glyph_cache_size;
@@ -210,6 +211,12 @@ pub const WM_APP_SHOW_CONNECT_DIALOG: c.UINT = c.WM_APP + 40;
 /// delta. Posted (not sent) because the callback runs on the core thread with
 /// grid_mu held, and SetWindowPos would re-enter updateLayoutToCore.
 pub const WM_APP_RESIZE_TO_GRID: c.UINT = c.WM_APP + 41;
+/// Posted when the pointer enters or leaves a message surface. wParam = 1 for
+/// entered, 0 for left; lParam = grid id. Posted (not sent) because the mouse
+/// message can be dispatched from a nested message pump inside DXGI Present,
+/// which runs while the core's grid lock is held — taking that lock from the
+/// handler directly would self-deadlock.
+pub const WM_APP_MSG_HOVER: c.UINT = c.WM_APP + 42;
 
 // =========================================================================
 // Timer IDs and timing constants
@@ -1931,6 +1938,10 @@ pub const ExternalWindow = struct {
     scrollbar_last_update: i64 = 0, // Timestamp for throttling
     // Pointer is over the decorated surface's copy-content button.
     copy_button_hover: bool = false,
+    // Pointer is over a message surface, reported to the core so it holds the
+    // view's auto-hide countdown. Tracked here so an ordinary mouse move does
+    // not take the core's grid lock on every WM_MOUSEMOVE.
+    msg_hover: bool = false,
     // OLE drop target (cmdline surface only). See ui/drop_target.zig; opaque
     // here so app.zig carries none of the COM plumbing.
     drop_target: ?*anyopaque = null,

--- a/windows/ui/external_windows.zig
+++ b/windows/ui/external_windows.zig
@@ -41,6 +41,22 @@ fn classifyExternalSurface(grid_id: i64) ExternalSurfaceKind {
     };
 }
 
+/// Report pointer enter/exit on a message surface so the core holds the view's
+/// auto-hide countdown while the user reads it or reaches for the copy button.
+/// Only transitions are posted, so an ordinary mouse move over the surface
+/// costs nothing.
+fn setMsgHover(app: *App, ext_win: *app_mod.ExternalWindow, grid_id: i64, hovered: bool) void {
+    switch (classifyExternalSurface(grid_id)) {
+        .msg_show, .msg_history => {},
+        else => return,
+    }
+    if (ext_win.msg_hover == hovered) return;
+    const hwnd = app.hwnd orelse return;
+    const wparam: c.WPARAM = if (hovered) 1 else 0;
+    if (c.PostMessageW(hwnd, app_mod.WM_APP_MSG_HOVER, wparam, @intCast(grid_id)) == 0) return;
+    ext_win.msg_hover = hovered;
+}
+
 /// Whether the decorated surface of `kind` shows a copy-content button.
 fn copyButtonEnabled(app: *App, kind: ExternalSurfaceKind) bool {
     return switch (kind) {
@@ -1803,6 +1819,18 @@ pub fn createExternalWindowOnUIThread(app: *App, req: app_mod.PendingExternalWin
         if (applog.isEnabled()) applog.appLog("[win] put message window below cmdline (cmdline created)\n", .{});
     }
 
+    // A message float routinely appears right under a stationary pointer, and
+    // no WM_MOUSEMOVE follows one that never moves. Seed the hover state from
+    // the cursor's actual position, after the deferred repositioning above has
+    // settled the window's final rect.
+    var window_rect: c.RECT = undefined;
+    var cursor: c.POINT = undefined;
+    if (c.GetWindowRect(hwnd, &window_rect) != 0 and c.GetCursorPos(&cursor) != 0) {
+        if (c.PtInRect(&window_rect, cursor) != 0) {
+            setMsgHover(app, ext_window_ptr, req.grid_id, true);
+        }
+    }
+
     // Activate this external window
     _ = c.SetForegroundWindow(hwnd);
     return .published;
@@ -2564,6 +2592,10 @@ pub export fn ExternalWndProc(
                         _ = c.InvalidateRect(hwnd, null, c.FALSE);
                     }
 
+                    // The pointer is somewhere on the surface, copy button
+                    // included — the message must not vanish under it.
+                    setMsgHover(app, ext_win, grid_id.?, true);
+
                     // Check for scrollbar hover
                     if (app.config.scrollbar.enabled and app.config.scrollbar.isHover()) {
                         var client: c.RECT = undefined;
@@ -2606,10 +2638,12 @@ pub export fn ExternalWndProc(
         c.WM_MOUSELEAVE => {
             if (app_mod.getApp(hwnd)) |app| {
                 app.mu.lockUncancelable(core.clock.io());
+                var grid_id: ?i64 = null;
                 var ext_window: ?*app_mod.ExternalWindow = null;
                 var it = app.external_windows.iterator();
                 while (it.next()) |entry| {
                     if (entry.value_ptr.*.hwnd == hwnd) {
+                        grid_id = entry.key_ptr.*;
                         ext_window = entry.value_ptr.*;
                         break;
                     }
@@ -2617,6 +2651,7 @@ pub export fn ExternalWndProc(
                 app.mu.unlock(core.clock.io());
 
                 if (ext_window) |ext_win| {
+                    setMsgHover(app, ext_win, grid_id.?, false);
                     if (ext_win.copy_button_hover) {
                         ext_win.copy_button_hover = false;
                         _ = c.InvalidateRect(hwnd, null, c.FALSE);

--- a/windows/window.zig
+++ b/windows/window.zig
@@ -4816,6 +4816,18 @@ pub export fn WndProc(
             return 0;
         },
 
+        app_mod.WM_APP_MSG_HOVER => {
+            if (getApp(hwnd)) |app| {
+                if (app.corep) |corep| {
+                    app_mod.zonvie_core_set_msg_hover(corep, @intCast(lParam), @intCast(wParam));
+                    // Pausing or resuming moved the earliest deadline, so the
+                    // timer armed for the old one has to be re-armed.
+                    armMsgThrottleTimer(hwnd, app);
+                }
+            }
+            return 0;
+        },
+
         app_mod.WM_APP_MSG_THROTTLE_ARM => {
             if (getApp(hwnd)) |app| {
                 app.msg_throttle_arm_posted.store(false, .release);


### PR DESCRIPTION
The ext_float copy button was unreachable in practice: the auto-hide countdown ran while the user moved onto the button, so the window vanished mid-reach.

The core already had a pause (scrolling the float stops the countdown) but it was not exported, so no frontend could ask for one. Add zonvie_core_set_msg_hover(core, grid_id, hovered): entering stops the countdown, leaving restarts it at FULL length. Restarting needs the timeout the view was shown with, so the show path now stores the duration alongside the deadline. A message landing on a float the pointer already rests on does not arm at all, and hideChannelView drops both the duration and the hover flag -- a window can close under a stationary pointer, and neither AppKit nor Win32 delivers a leave event for a window that is gone.

Additive export only: no struct layout, callback signature, or enum value changes.

macOS uses a hover-tracking container view rather than ExternalGridView, which skips hover handling for decorated surfaces; tracking at container level also means moving onto the copy button subview is not an exit. AppKit posts no mouseEntered for an area installed under a pointer that never moves, so the container seeds its state from the cursor position. Windows tracks WM_MOUSEMOVE/WM_MOUSELEAVE and seeds the same way from GetCursorPos at window creation.

Both frontends DEFER the core call rather than making it inline (DispatchQueue.main.async / WM_APP_MSG_HOVER). grid_mu is not reentrant, and a tracking-area update or a nested message pump inside DXGI Present can dispatch the mouse event from inside a core callback that already holds it.

Only transitions cross the ABI; no per-frame or per-cell work is added.

Tests: five in flush.zig (pause on enter, full-length re-arm on exit, no arming while hovered, no resurrection after hide, timeout=0 stays un-armed). zig build test 628/628, xcodebuild and the Windows target both green. Hardware smoke pending on both platforms.